### PR TITLE
Fix release.yml Docker build-args

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,4 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GO_VERSION='-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}'
+          build-args: LDFLAGS='-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}'


### PR DESCRIPTION
## Motivation

`LDFLAGS` is the right argument name to pass to Docker build.
![image](https://github.com/nobl9/sloctl/assets/48822818/07ce4a57-e562-40a0-a7cd-23fd907b445d)
