### PR TITLE
fix: Unquote ldflags in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,4 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: LDFLAGS='-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}'
+          build-args: LDFLAGS=-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}


### PR DESCRIPTION
## Motivation

`LDFLAGS` Docker argument should not be quoted since this causes:

```
invalid value "'-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=v0.0.98'" for flag -ldflags: parameter may not start with quote character '
```