### PR TITLE
chore: Correct check-generate

### DIFF
--- a/scripts/check-generate.sh
+++ b/scripts/check-generate.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-ENUM_PATH="*_enum.go"
 TMP_DIR=$(mktemp -d)
 
 cleanup_git() {
@@ -16,7 +15,7 @@ main() {
 
   make -C "$TMP_DIR" generate
 
-  CHANGED=$(git -C "$TMP_DIR" diff --name-only "${ENUM_PATH}")
+  CHANGED=$(git -C "$TMP_DIR" diff --name-only)
   if [ -n "${CHANGED}" ]; then
     printf >&2 "There are generated changes that are not committed:\n%s\n" "$CHANGED"
     exit 1


### PR DESCRIPTION
## Motivation

Checking generated files should not be limited to `_enum.go` files only.