### PR TITLE
chore: Introduce SOC-2 compliant release process

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,8 +1,28 @@
 name: End-to-end tests
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      clientId:
+        description: Client ID to use for authentication
+        required: true
+        type: string
+      oktaOrgUrl:
+        description: Okta organization URL
+        required: false
+        type: string
+      oktaAuthServer:
+        description: Okta authentication server identifier
+        required: false
+        type: string
+      ref:
+        description: Reference branch, tag or commit SHA to checkout
+        required: false
+        type: string
+        default: main
+    secrets:
+      clientSecret:
+        description: Client secret to use for authentication
+        required: true
 jobs:
   test:
     name: Run e2e tests
@@ -10,12 +30,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          repository: nobl9/sloctl
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: false
       - name: Run tests
-        run: make test/e2e
         env:
-          SLOCTL_CLIENT_ID: ${{ vars.SLOCTL_CLIENT_ID }}
-          SLOCTL_CLIENT_SECRET: ${{ secrets.SLOCTL_CLIENT_SECRET }}
+          SLOCTL_CLIENT_ID: ${{ inputs.clientId }}
+          SLOCTL_CLIENT_SECRET: ${{ secrets.clientSecret }}
+          SLOCTL_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
+          SLOCTL_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
+        run: make test/e2e

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -2,15 +2,20 @@ name: Release candidate
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 jobs:
+  test:
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      clientId: "${{ vars.SLOCTL_CLIENT_ID }}"
+      ref: "${{ github.ref_name }}"
+    secrets:
+      clientSecret: "${{ secrets.SLOCTL_CLIENT_SECRET }}"
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -23,3 +28,4 @@ jobs:
           args: release --clean --skip=homebrew
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,23 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
+  test:
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      clientId: "${{ vars.SLOCTL_CLIENT_ID }}"
+      ref: "${{ github.ref_name }}"
+    secrets:
+      clientSecret: "${{ secrets.SLOCTL_CLIENT_SECRET }}"
+  qa:
+    runs-on: ubuntu-latest
+    environment: qa-approval
+    steps:
+      - name: No-op approval
+        run: echo "This is a no-op step, QA needs to approve it and may perform testing beforehand"
   release:
     runs-on: ubuntu-latest
-    environment: release
+    needs: [test, qa]
+    environment: management-approval
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -43,6 +57,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Motivation

Use GH environments and a no-op step along with `needs` chaining to achieve a flow where both QA and management have to approve the release.

I also parametrized e2e tests, we might want to trigger these tests from other places too.

I also fixed the issue with Goreleaser, ref: https://github.com/nobl9/terraform-provider-nobl9/pull/182
