### PR TITLE
chore: Update README.md logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
    <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github.com/nobl9/n9/assets/84388336/2895fcab-a386-498f-b7c4-14a70c66093d">
       <source media="(prefers-color-scheme: light)" srcset="https://github.com/nobl9/n9/assets/84388336/b21abc8b-8b05-448b-a8bc-5576c72e81b5">
-      <img alt="N9" src="https://github.com/nobl9/n9/assets/84388336/b21abc8b-8b05-448b-a8bc-5576c72e81b5" width="500" />
+      <img alt="N9" src="https://github.com/nobl9/sloctl/assets/48822818/e137ac37-a299-4a24-951d-197642d31b1a" width="500" />
    </picture>
 </h1>
 


### PR DESCRIPTION
The previous logo was referencing the wrong asset.

