### PR TITLE
chore: Use JSON numbers with updated SDK

### DIFF
--- a/.github/workflows/e2e-tests-dispatch.yml
+++ b/.github/workflows/e2e-tests-dispatch.yml
@@ -1,0 +1,30 @@
+name: End-to-end tests dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      clientId:
+        description: Client ID to use for authentication
+        required: true
+        type: string
+      clientSecret:
+        description: Client secret to use for authentication
+        type: string
+        required: true
+      oktaOrgUrl:
+        description: Okta organization URL
+        required: false
+        type: string
+      oktaAuthServer:
+        description: Okta authentication server identifier
+        required: false
+        type: string
+jobs:
+  test:
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      clientId: "${{ inputs.clientId }}"
+      ref: "${{ github.ref_name }}"
+      oktaOrgUrl: "${{ inputs.oktaOrgUrl }}"
+      oktaAuthServer: "${{ inputs.oktaAuthServer }}"
+    secrets:
+      clientSecret: "${{ inputs.clientSecret }}"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/nobl9/nobl9-go v0.79.1
+	github.com/nobl9/nobl9-go v0.79.2
 	github.com/pkg/errors v0.9.1
 	github.com/schollz/progressbar/v3 v3.14.2
 	github.com/spf13/cobra v1.8.0
@@ -18,7 +18,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/MicahParks/jwkset v0.5.17 // indirect
 	github.com/MicahParks/keyfunc/v3 v3.3.2 // indirect
-	github.com/aws/aws-sdk-go v1.51.10 // indirect
+	github.com/aws/aws-sdk-go v1.51.11 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/MicahParks/jwkset v0.5.17 h1:DrcwyKwSP5adD0G2XJTvDulnWXjD6gbjROMgMXDb
 github.com/MicahParks/jwkset v0.5.17/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
 github.com/MicahParks/keyfunc/v3 v3.3.2 h1:YTtwc4dxalBZKFqHhqctBWN6VhbLdGhywmne9u5RQVM=
 github.com/MicahParks/keyfunc/v3 v3.3.2/go.mod h1:GJBeEjnv25OnD9y2OYQa7ELU6gYahEMBNXINZb+qm34=
-github.com/aws/aws-sdk-go v1.51.10 h1:/g8K1SllwdCnsVw2BFXsYd+TS5P75skj5a8QFbfdW0U=
-github.com/aws/aws-sdk-go v1.51.10/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.51.11 h1:El5VypsMIz7sFwAAj/j06JX9UGs4KAbAIEaZ57bNY4s=
+github.com/aws/aws-sdk-go v1.51.11/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -53,8 +53,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/nobl9/nobl9-go v0.79.1 h1:d5esYhnO91s/nK/EUxhuKlHLOIGSSKU/QxtMtnAwMd4=
-github.com/nobl9/nobl9-go v0.79.1/go.mod h1:CZ0bJwn5dMAl5dZ8EyFKU3nyPA8wBXR8F6b8fp4j8U8=
+github.com/nobl9/nobl9-go v0.79.2 h1:4Zeo8I2JEi/uW/gjcm9lb41O6locV68fCzul6mq3MqQ=
+github.com/nobl9/nobl9-go v0.79.2/go.mod h1:KVIRTmt2nu9d/tP6urcs5uC6otoA2LyOjZrE35mJL+A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/root.go
+++ b/internal/root.go
@@ -104,6 +104,9 @@ func (r *RootCmd) setupClient() error {
 	r.Client.SetUserAgent(getUserAgent())
 	// Use generic object representation instead of concrete models for sloctl to be version agnostic.
 	v1alphaParser.UseGenericObjects = true
+	// Decode JSON numbers into [json.Number] in order to properly handle integers and floats.
+	// If we don't use this option, all numbers will be converted to floats, including integers.
+	v1alphaParser.UseJSONNumber = true
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

With the change in SDK behaviour in favour of optional JSON numbers handling we need to turn the flag on in order to retain correct JSON numbers handling.

## Related changes

https://github.com/nobl9/nobl9-go/pull/350