### PR TITLE
feat: PC-12282 Introduce metadata annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/nobl9/sloctl
 
 go 1.22
 
-toolchain go1.22.2
-
 require (
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/goccy/go-yaml v1.11.3

--- a/test/get.bats
+++ b/test/get.bats
@@ -234,7 +234,7 @@ verify_get_success() {
 	# we need to hack our way around it.
 	refute_output --partial "Available Commands:"
 	# We can't retrieve the same object we applied so we need to compare the minimum.
-	filter='[.[] | {"name": .metadata.name, "project": .metadata.project, "labels": .metadata.labels}] | sort_by(.name, .project)'
+	filter='[.[] | {"name": .metadata.name, "project": .metadata.project, "labels": .metadata.labels, "annotations": .metadata.annotations}] | sort_by(.name, .project)'
 	assert_equal \
 		"$(yq --sort-keys -y -r "$filter" <<<"$have")" \
 		"$(yq --sort-keys -y -r "$filter" <<<"$want")"

--- a/test/inputs/get/alertpolicies.yaml
+++ b/test/inputs/get/alertpolicies.yaml
@@ -3,6 +3,9 @@
   metadata:
     name: trigger-alert-immediately
     project: death-star
+    annotations:
+      registry: docker.io
+      visibility: internal
   spec:
     description: Dummy AlertPolicy for 'sloctl get' e2e tests
     severity: Medium

--- a/test/inputs/get/projects.yaml
+++ b/test/inputs/get/projects.yaml
@@ -2,6 +2,8 @@
   kind: Project
   metadata:
     name: death-star
+    annotations:
+      registry: docker.io
     labels:
       purpose:
       - defensive
@@ -16,6 +18,8 @@
   metadata:
     displayName: Hoth Base
     name: hoth-base
+    annotations:
+      language: Go
     labels:
       purpose:
       - defensive

--- a/test/inputs/get/services.yaml
+++ b/test/inputs/get/services.yaml
@@ -4,6 +4,8 @@
     displayName: Destroyer
     name: destroyer
     project: death-star
+    annotations:
+      registry: docker.io
   spec:
     description: Dummy Service for 'sloctl get' e2e tests
 - apiVersion: n9/v1alpha

--- a/test/inputs/get/slos.yaml
+++ b/test/inputs/get/slos.yaml
@@ -3,6 +3,8 @@
   metadata:
     name: tokyo-server-6-latency
     project: death-star
+    annotations:
+      registry: docker.io
   spec:
     description: This SLO is just for the e2e 'sloctl get' tests, it's not supposed to work!
     service: destroyer

--- a/test/outputs/get/alertpolicy.yaml
+++ b/test/outputs/get/alertpolicy.yaml
@@ -3,6 +3,9 @@
   metadata:
     name: trigger-alert-immediately
     project: death-star
+    annotations:
+      registry: docker.io
+      visibility: internal
   spec:
     description: Dummy AlertPolicy for 'sloctl get' e2e tests
     conditions:


### PR DESCRIPTION
This PR introduces a mechanism for users to define annotations on SLOs, Services, Projects, and Alert Policies (the same objects to which we can assign labels).
Similarly to Kubernetes, users can use either labels or annotations to attach metadata to objects.

Annotations, similarly to k8s annotations, are defined as key/value maps:

```json
"metadata": {
  "annotations": {
    "key1" : "value1",
    "key2" : "value2"
  }
}
```

## Release Notes

Added the ability to define metadata annotations on `SLOs`, `Services`, `Projects`, and `Alert Policies`.
Similarly to Kubernetes, users can now use either labels or annotations to attach metadata to objects.