### PR TITLE
chore: Pin yq version for tests

### DIFF
--- a/test/docker/Dockerfile.e2e
+++ b/test/docker/Dockerfile.e2e
@@ -2,7 +2,7 @@ FROM bats/bats:1.11.0
 
 RUN apk --no-cache --update add \
   gettext jq git python3 py3-pip
-RUN pip install yq --break-system-packages
+RUN pip install yq==v3.2.3 --break-system-packages
 
 WORKDIR /sloctl
 

--- a/test/docker/Dockerfile.unit
+++ b/test/docker/Dockerfile.unit
@@ -2,7 +2,7 @@ FROM bats/bats:1.11.0
 
 RUN apk --no-cache --update add \
   gettext jq git python3 py3-pip
-RUN pip install yq --break-system-packages
+RUN pip install yq==v3.2.3 --break-system-packages
 
 WORKDIR /sloctl
 


### PR DESCRIPTION
## Motivation

Until https://github.com/kislyuk/yq/issues/187 is resolved, yq has to be pinned to a previous version.