### PR TITLE
chore: Fix goreleaser marking pre-releases as latest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ checksum:
   algorithm: sha256
 
 release:
+  make_latest: fase
   github:
     owner: nobl9
     name: sloctl


### PR DESCRIPTION
## Motivation

Goreleaser is currently marking release candidate releases as `latest`, this is an unwanted behaviour.
In order to prevent the tool from doing that we need to set `make_latest` to false.

Ref: https://goreleaser.com/customization/release/?h=#github