### PR TITLE
chore: Update pr-title.yml

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,5 +9,5 @@ jobs:
     steps:
     - uses: Slashgear/action-check-pr-title@v4.3.0
       with:
-        regexp: "(feat|fix|sec|infra|test|chore|doc): .{5,}"
+        regexp: "^(feat|fix|sec|infra|test|chore|doc): .{5,}"
         helpMessage: "Example: 'feat: new pr title check BE-143' <- prefix, colon, space, PR title of at least 5 chars (with ticket number strongly suggested, but not mandatory)"


### PR DESCRIPTION
Regexp in its current form allows defining PR titles which do not start with specified prefixes.