### PR TITLE
chore: Fix typo in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ checksum:
   algorithm: sha256
 
 release:
-  make_latest: fase
+  make_latest: false
   github:
     owner: nobl9
     name: sloctl


### PR DESCRIPTION
Correct `release.make_latest` field value to proper boolean: `false`.