### PR TITLE
chore: use supported direct type for e2e tests [PC-12979]

### DIFF
--- a/test/aws-iam-ids.bats
+++ b/test/aws-iam-ids.bats
@@ -30,7 +30,7 @@ setup() {
 }
 
 @test "direct" {
-	run_sloctl aws-iam-ids direct splunk-observability-direct
+	run_sloctl aws-iam-ids direct splunk-direct
 	assert_success
 	assert_output --regexp "externalID: [-a-zA-Z0-9]+\naccountID: \"\d+\""
 }

--- a/test/get.bats
+++ b/test/get.bats
@@ -160,7 +160,7 @@ setup() {
 }
 
 @test "check full direct output" {
-	run_sloctl get direct -p death-star splunk-observability-direct
+	run_sloctl get direct -p death-star splunk-direct
 	assert_success
 	assert_equal \
 		"$(yq --sort-keys -y -r . <<<"$output")" \

--- a/test/inputs/aws-iam-ids/direct.yaml
+++ b/test/inputs/aws-iam-ids/direct.yaml
@@ -7,14 +7,14 @@
 - apiVersion: n9/v1alpha
   kind: Direct
   metadata:
-    name: splunk-observability-direct
-    displayName: Splunk Observability direct
+    name: splunk-direct
+    displayName: Splunk direct
     project: death-star
   spec:
     description: This Direct is just for the e2e 'sloctl aws-iam-ids' tests, it's not supposed to work!
     sourceOf:
       - Metrics
       - Services
-    splunkObservability:
-      realm: us1
-      accessToken: super-secret
+    splunk:
+      accessToken: "theaccesstoken"
+      url: "https://splunk.example.com"

--- a/test/inputs/get/alertsilences.yaml
+++ b/test/inputs/get/alertsilences.yaml
@@ -5,7 +5,7 @@
     project: death-star
   spec:
     description: Dummy AlertSilence for 'sloctl get' e2e tests
-    slo: tokyo-server-6-latency
+    slo: splunk-raw-rolling
     alertPolicy:
       name: trigger-alert-immediately
     period:

--- a/test/inputs/get/annotations.yaml
+++ b/test/inputs/get/annotations.yaml
@@ -14,7 +14,7 @@
     name: tate-nano
     project: death-star
   spec:
-    slo: tokyo-server-6-latency
+    slo: splunk-raw-rolling
     description: Dummy Annotation for 'sloctl get' e2e tests
     startTime: 2023-01-02T17:20:05Z
     endTime: 2023-01-02T17:30:05Z

--- a/test/inputs/get/budgetadjustments.yaml
+++ b/test/inputs/get/budgetadjustments.yaml
@@ -10,7 +10,7 @@
     rrule: FREQ=WEEKLY;INTERVAL=1
     filters:
       slos:
-        - name: tokyo-server-6-latency
+        - name: splunk-raw-rolling
           project: death-star
 - apiVersion: n9/v1alpha
   kind: BudgetAdjustment

--- a/test/inputs/get/directs.yaml
+++ b/test/inputs/get/directs.yaml
@@ -12,14 +12,14 @@
 - apiVersion: n9/v1alpha
   kind: Direct
   metadata:
-    name: splunk-observability-direct
-    displayName: Splunk Observability direct
+    name: splunk-direct
+    displayName: Splunk direct
     project: death-star
   spec:
     description: This Direct is just for the e2e 'sloctl get' tests, it's not supposed to work!
-    splunkObservability:
-      realm: us1
-      accessToken: super-secret
+    splunk:
+      accessToken: ""
+      url: "https://splunk.example.com"
     queryDelay:
       unit: Minute
       value: 5

--- a/test/inputs/get/directs.yaml
+++ b/test/inputs/get/directs.yaml
@@ -18,7 +18,7 @@
   spec:
     description: This Direct is just for the e2e 'sloctl get' tests, it's not supposed to work!
     splunk:
-      accessToken: ""
+      accessToken: "theaccesstoken"
       url: "https://splunk.example.com"
     queryDelay:
       unit: Minute

--- a/test/inputs/get/slos.yaml
+++ b/test/inputs/get/slos.yaml
@@ -1,7 +1,7 @@
 - apiVersion: n9/v1alpha
   kind: SLO
   metadata:
-    name: tokyo-server-6-latency
+    name: splunk-raw-rolling
     project: death-star
     annotations:
       registry: docker.io
@@ -11,7 +11,7 @@
     indicator:
       metricSource:
         kind: Direct
-        name: splunk-observability-direct
+        name: splunk-direct
     timeWindows:
       - unit: Day
         count: 1
@@ -28,8 +28,8 @@
         primary: true
         rawMetric:
           query:
-            splunkObservability:
-              program: "data('demo.trans.latency', filter=filter('demo_datacenter', 'Tokyo') and filter('demo_host', 'server6')).mean().publish()"
+            splunk:
+              query: "index=* source=udp:5072 sourcetype=syslog status<400 | bucket _time span=1m | stats avg(response_time) as n9value by _time | rename _time as n9time | fields n9time n9value"
     alertPolicies:
       - trigger-alert-immediately
       - budget-will-be-burn-in-3days

--- a/test/outputs/get/direct.yaml
+++ b/test/outputs/get/direct.yaml
@@ -1,8 +1,8 @@
 - apiVersion: n9/v1alpha
   kind: Direct
   metadata:
-    displayName: Splunk Observability direct
-    name: splunk-observability-direct
+    displayName: Splunk direct
+    name: splunk-direct
     project: death-star
   spec:
     description: This Direct is just for the e2e 'sloctl get' tests, it's not supposed to work!
@@ -10,8 +10,8 @@
       unit: Minute
       value: 5
     releaseChannel: stable
-    splunkObservability:
+    splunk:
       accessToken: '[hidden]'
-      realm: us1
+      url: "https://splunk.example.com"
   status:
-    directType: SplunkObservability
+    directType: Splunk

--- a/test/outputs/get/direct.yaml
+++ b/test/outputs/get/direct.yaml
@@ -6,12 +6,28 @@
     project: death-star
   spec:
     description: This Direct is just for the e2e 'sloctl get' tests, it's not supposed to work!
+    historicalDataRetrieval:
+      defaultDuration:
+        unit: Day
+        value: 0
+      maxDuration:
+        unit: Day
+        value: 0
+    interval:
+      unit: Minute
+      value: 1
+    jitter:
+      unit: Second
+      value: 20
     queryDelay:
       unit: Minute
       value: 5
     releaseChannel: stable
     splunk:
       accessToken: '[hidden]'
-      url: "https://splunk.example.com"
+      url: https://splunk.example.com
+    timeout:
+      unit: Second
+      value: 30
   status:
     directType: Splunk


### PR DESCRIPTION
## Motivation

The Splunk Observability integration is not actively supported. End to end tests using it may me flaky. 

## Summary

Change Splunk Observability direct used in e2e tests to Splunk.

## Testing

- run e2e test

