### PR TITLE
fix: Switch to distroless image in Dockerfile [PC-13119]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 go build \
   -o /artifacts/sloctl \
   "${PWD}/cmd/sloctl"
 
-FROM scratch
+FROM gcr.io/distroless/static-debian12
 
 COPY --from=builder /artifacts/sloctl /usr/bin/sloctl
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -28,6 +28,7 @@ ignorePaths:
   - "**/test_data/**"
   - dist/**
 words:
+  - distroless
   - dynatrace
   - endef
   - gobin


### PR DESCRIPTION
## Motivation

Currently, we're missing certificates in our Docker image, so it won't work.

```
Post "https://accounts.nobl9.com/oauth2/auseg9kiegWKEtJZC416/v1/token": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## Summary

Switch to [distroless](https://github.com/GoogleContainerTools/distroless) image which has certificates baked in.

## Related changes

Similar problem I've encountered recently in another project: https://github.com/nieomylnieja/go-libyear/commit/c7faae7e234a56cb07c5a46571168e10a7d5f9a6

## Testing

```shell
make docker
docker run -e SLOCTL_CLIENT_ID=$CLIENT_ID -e SLOCTL_CLIENT_SECRET=$CLIENT_SECRET sloctl get slos
```

## Release Notes

Fixed missing TLS certificates from Docker image.

