### PR TITLE
chore: change folder to directory in brews Goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,4 +57,4 @@ brews:
       For more information on how to use the command-line client
       and the Nobl9 managed cloud service, visit:
         https://docs.nobl9.com/sloctl-user-guide
-    folder: Formula
+    directory: Formula


### PR DESCRIPTION
## Motivation

`brews.folder` is deprecated as per https://goreleaser.com/deprecations/#__tabbed_4_1.

## Summary

Changed `brews.folder` to `brews.directory`.
