### PR TITLE
chore: Adjust e2e tests for createdAt and createdBy new v1alpha Project.Spec fields

### DIFF
--- a/test/apply-and-delete.bats
+++ b/test/apply-and-delete.bats
@@ -57,6 +57,7 @@ EOF
 	assert_deleted "$(read_files "$input")"
 }
 
+# bats test_tags=bats:focus
 @test "read single object from file" {
 	input="${TEST_INPUTS}/single-object.yaml"
 

--- a/test/apply-and-delete.bats
+++ b/test/apply-and-delete.bats
@@ -57,7 +57,6 @@ EOF
 	assert_deleted "$(read_files "$input")"
 }
 
-# bats test_tags=bats:focus
 @test "read single object from file" {
 	input="${TEST_INPUTS}/single-object.yaml"
 


### PR DESCRIPTION
## Motivation

With the introduction of new server-side computed fields for v1alpha Project.Spec: `createdAt` and `createdBy` the tests started failing as the helper function `_assert_objects_existence` was comparing almost the whole object.
This is too much for a simple assertion that checks if the object was actually applied, so I added additional filter to re-map the objects, extracting the basic minimum for comparison.

Ref: https://github.com/nobl9/sloctl/actions/runs/9466510383/job/26078347437

## Related Changes

- https://github.com/nobl9/nobl9-go/pull/422

## Testing

Run `make test/e2e`, remember about supplying the right env vars OR run https://github.com/nobl9/sloctl/actions/workflows/e2e-tests-dispatch.yml with this branch as target.