### PR TITLE
chore: Bump Go version to 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.18 AS builder
+FROM golang:1.22.4-alpine3.19 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/sloctl
 
-go 1.22
+go 1.22.4
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0


### PR DESCRIPTION
## Motivation

Resolves the issue https://nvd.nist.gov/vuln/detail/CVE-2024-24790

## Release Notes

Go version has been updated to 1.22.4 to resolve critical level vuln in stdlib (https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
