### PR TITLE
chore: Add Docker image tests

### DIFF
--- a/.github/workflows/e2e-tests-dispatch.yml
+++ b/.github/workflows/e2e-tests-dispatch.yml
@@ -18,13 +18,25 @@ on:
         description: Okta authentication server identifier
         required: false
         type: string
+      target:
+        description: Makefile test target to run
+        required: false
+        type: string
+      sloctlImage:
+        description: > 
+          Sloctl docker image to use for e2e docker image tests.
+          If not provided, the image will be built inside the workflow.
+        type: string
+        required: false
 jobs:
   test:
     uses: ./.github/workflows/e2e-tests.yml
     with:
-      clientId: "${{ inputs.clientId }}"
-      ref: "${{ github.ref_name }}"
-      oktaOrgUrl: "${{ inputs.oktaOrgUrl }}"
-      oktaAuthServer: "${{ inputs.oktaAuthServer }}"
+      clientId: ${{ inputs.clientId }}
+      ref: ${{ github.ref_name }}
+      oktaOrgUrl: ${{ inputs.oktaOrgUrl }}
+      oktaAuthServer: ${{ inputs.oktaAuthServer }}
+      sloctlImage: ${{ inputs.sloctlImage }}
+      target: ${{ inputs.target }}
     secrets:
-      clientSecret: "${{ inputs.clientSecret }}"
+      clientSecret: ${{ inputs.clientSecret }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,6 +19,17 @@ on:
         required: false
         type: string
         default: main
+      target:
+        description: Makefile test target to run
+        required: false
+        type: string
+        default: test/e2e
+      sloctlImage:
+        description: > 
+          Sloctl docker image to use for e2e docker image tests.
+          If not provided, the image will be built inside the workflow.
+        type: string
+        required: false
     secrets:
       clientSecret:
         description: Client secret to use for authentication
@@ -41,6 +52,8 @@ jobs:
         env:
           SLOCTL_CLIENT_ID: ${{ inputs.clientId }}
           SLOCTL_CLIENT_SECRET: ${{ secrets.clientSecret }}
-          SLOCTL_OKTA_ORG_URL: "${{ inputs.oktaOrgUrl }}"
-          SLOCTL_OKTA_AUTH_SERVER: "${{ inputs.oktaAuthServer }}"
-        run: make test/e2e
+          SLOCTL_OKTA_ORG_URL: ${{ inputs.oktaOrgUrl }}
+          SLOCTL_OKTA_AUTH_SERVER: ${{ inputs.oktaAuthServer }}
+          SLOCTL_E2E_DOCKER_TEST_IMAGE: ${{ inputs.sloctlImage }}
+          TEST_TARGET: ${{ inputs.target }}
+        run: make "$TEST_TARGET"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,11 @@ jobs:
   test:
     uses: ./.github/workflows/e2e-tests.yml
     with:
-      clientId: "${{ vars.SLOCTL_CLIENT_ID }}"
-      ref: "${{ github.ref_name }}"
+      clientId: ${{ vars.SLOCTL_CLIENT_ID }}
+      ref: ${{ github.ref_name }}
+      target: test/bats/e2e
     secrets:
-      clientSecret: "${{ secrets.SLOCTL_CLIENT_SECRET }}"
+      clientSecret: ${{ secrets.SLOCTL_CLIENT_SECRET }}
   qa-approval:
     runs-on: ubuntu-latest
     environment: qa-approval
@@ -74,3 +75,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: LDFLAGS=-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}
+  docker-test:
+    uses: ./.github/workflows/e2e-tests.yml
+    needs: [goreleaser]
+    strategy:
+      matrix:
+        image: [nobl9/sloctl, quay.io/nobl9/sloctl]
+    with:
+      clientId: ${{ vars.SLOCTL_CLIENT_ID }}
+      ref: ${{ github.ref_name }}
+      sloctlImage: ${{ matrix.image }}:${{ github.ref_name }}
+      target: test/go/e2e-docker
+    secrets:
+      clientSecret: "${{ secrets.SLOCTL_CLIENT_SECRET }}"

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,19 @@ docker:
 ## Run all unit tests.
 test/unit: test/go/unit test/bats/unit
 
-.PHONY: test/e2e
+.PHONY: test/e2e test/bats/unit test/bats/e2e test/go/e2e-docker
 ## Run all e2e tests.
-test/e2e: test/bats/e2e
+test/e2e: test/bats/e2e test/go/e2e-docker
 
 ## Run go unit tests.
 test/go/unit:
 	$(call _print_step,Running go unit tests)
 	go test -race -cover ./...
+
+## Run go e2e docker tests.
+test/go/e2e-docker:
+	$(call _print_step,Running go docker image tests)
+	go test -race -tags=e2e_test ./...
 
 ## Run bats unit tests.
 test/bats/unit:
@@ -85,7 +90,7 @@ test/bats/unit:
 	docker run -e TERM=linux --rm \
 		sloctl-bats-unit -F pretty --filter-tags unit $(TEST_DIR)/*
 
-## Run bats unit tests.
+## Run bats e2e tests.
 test/bats/e2e:
 	$(call _print_step,Running bats e2e tests)
 	$(call _build_docker,sloctl-e2e-test-bin,$(VERSION),$(BRANCH),$(REVISION))

--- a/test/dockertest/docker_test.go
+++ b/test/dockertest/docker_test.go
@@ -1,0 +1,168 @@
+//go:build e2e_test
+
+package dockertest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/nobl9/nobl9-go/manifest"
+	v1alphaProject "github.com/nobl9/nobl9-go/manifest/v1alpha/project"
+	"github.com/nobl9/nobl9-go/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	once        sync.Once
+	dockerImage = "sloctl"
+	moduleRoot  = findModuleRoot()
+	tpl         = template.Must(
+		template.New("project.tmpl.yaml").
+			ParseFiles(filepath.Join(moduleRoot, "test", "inputs", "dockertest", "project.tmpl.yaml")))
+)
+
+func TestDocker(t *testing.T) {
+	setup(t)
+	projectName := fmt.Sprintf("sloctl-docker-e2e-test-%d", time.Now().UnixNano())
+
+	var (
+		applyBuf  bytes.Buffer
+		deleteBuf bytes.Buffer
+	)
+	tplBuf := io.MultiWriter(&applyBuf, &deleteBuf)
+	err := tpl.Execute(tplBuf, map[string]interface{}{"Name": projectName})
+	require.NoError(t, err)
+
+	t.Log("Applying:\n", applyBuf.String())
+	out := runSloctl(t, &applyBuf, "apply", "-f", "-")
+	assert.Equal(t, "The resources were successfully applied.\n", out.String())
+
+	t.Log("Fetching Project:", projectName)
+	out = runSloctl(t, nil, "get", "project", projectName)
+	objects, err := sdk.ReadObjectsFromSources(context.Background(), sdk.NewObjectSourceReader(out, ""))
+	require.NoError(t, err)
+	projects := manifest.FilterByKind[v1alphaProject.Project](objects)
+	assert.Len(t, projects, 1)
+	project := projects[0]
+	assert.NotNil(t, project.Spec.CreatedAt)
+	assert.NotNil(t, project.Spec.CreatedBy)
+	project.Spec.CreatedAt = ""
+	project.Spec.CreatedBy = ""
+	assert.Equal(t, v1alphaProject.Project{
+		APIVersion: manifest.VersionV1alpha,
+		Kind:       manifest.KindProject,
+		Metadata: v1alphaProject.Metadata{
+			Name:        projectName,
+			DisplayName: projectName,
+			Labels: map[string][]string{
+				"origin": {"sloctl-e2e-tests"},
+			},
+			Annotations: map[string]string{
+				"team": "green",
+			},
+		},
+		Spec: v1alphaProject.Spec{
+			Description: "Dummy Project for sloctl docker image e2e tests",
+		},
+	}, project)
+
+	t.Log("Deleting Project:", projectName)
+	out = runSloctl(t, &deleteBuf, "delete", "-f", "-")
+	assert.Equal(t, "The resources were successfully deleted.\n", out.String())
+
+	t.Log("Fetching Project:", projectName, "in order to ensure it was deleted")
+	out = runSloctl(t, nil, "get", "project", projectName)
+	assert.Equal(t, "No resources found.\n", out.String())
+}
+
+func setup(t *testing.T) {
+	t.Helper()
+	once.Do(func() {
+		if imageOverride := os.Getenv("SLOCTL_E2E_DOCKER_TEST_IMAGE"); imageOverride != "" {
+			dockerImage = imageOverride
+			t.Log("Using sloctl image override:", dockerImage)
+			return
+		}
+		gitBranch := mustExecCmd(t, exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")).String()
+		gitRevision := mustExecCmd(t, exec.Command("git", "rev-parse", "--short=8", "HEAD")).String()
+		dockerImage = "sloctl-docker-test"
+		_ = mustExecCmd(t, exec.Command("docker",
+			"build",
+			"--build-arg",
+			fmt.Sprintf(`LDFLAGS=-X %[1]s.BuildVersion=%[2]s -X %[1]s.BuildGitBranch=%[3]s -X %[1]s.BuildGitRevision=%[4]s`,
+				"github.com/nobl9/sloctl/internal", "", gitBranch, gitRevision),
+			"-t", dockerImage,
+			"../../.",
+		))
+	})
+}
+
+var sloctlEnvVars = []string{
+	"SLOCTL_CLIENT_ID",
+	"SLOCTL_CLIENT_SECRET",
+	"SLOCTL_OKTA_ORG_URL",
+	"SLOCTL_OKTA_AUTH_SERVER",
+}
+
+func runSloctl(t *testing.T, input io.Reader, sloctlArgs ...string) *bytes.Buffer {
+	args := []string{"run", "-i", "--rm"}
+	for _, env := range sloctlEnvVars {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", env, os.Getenv(env)))
+	}
+	args = append(args, dockerImage)
+	args = append(args, sloctlArgs...)
+	cmd := exec.Command("docker", args...)
+	if input != nil {
+		cmd.Stdin = input
+	}
+	return mustExecCmd(t, cmd)
+}
+
+func mustExecCmd(t *testing.T, cmd *exec.Cmd) *bytes.Buffer {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if cmd.Stdout == nil {
+		cmd.Stdout = &stdout
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = &stderr
+	}
+	if err := cmd.Run(); err != nil {
+		cmdStr := cmd.String()
+		secret := os.Getenv("SLOCTL_CLIENT_SECRET")
+		cmdStr = strings.ReplaceAll(cmdStr, secret, "***")
+		t.Fatalf("Failed to execute '%s' command: %s", cmdStr, stderr.String())
+	}
+	return &stdout
+}
+
+// findModuleRoot returns the absolute path to the modules root.
+func findModuleRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	dir = filepath.Clean(dir)
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil && !fi.IsDir() {
+			return dir
+		}
+		d := filepath.Dir(dir)
+		if d == dir {
+			break
+		}
+		dir = d
+	}
+	return ""
+}

--- a/test/inputs/dockertest/project.tmpl.yaml
+++ b/test/inputs/dockertest/project.tmpl.yaml
@@ -1,0 +1,12 @@
+apiVersion: n9/v1alpha
+kind: Project
+metadata:
+  name: {{ .Name }}
+  displayName: {{ .Name }}
+  labels:
+    origin:
+      - sloctl-e2e-tests
+  annotations:
+    team: green
+spec:
+  description: Dummy Project for sloctl docker image e2e tests


### PR DESCRIPTION
## Motivation

Currently we're not really testing the `Dockerfile` image directly nor the built images.
In our `bats` tests we're just using the Dockerfile to build the sloctl binary and copy it to bats container.
Since running dind (Docker in Docker) images has proven tricky to me I've decided to write this basic tests in Go instead.
The tests should only check basic interactions and not cover the larger spectrum that `bats` tests cover.

## Summary

Updated workflows for e2e tests as well as release workflow.

## Testing

Run:

```shell
SLOCTL_CLIENT_ID=<ID> SLOCTL_CLIENT_SECRET=*** SLOCTL_OKTA_ORG_URL=<ORG_URL> SLOCTL_OKTA_AUTH_SERVER=<SERVER> SLOCTL_E2E_DOCKER_TEST_IMAGE=nobl9/sloctl make test/go/e2e
```

Note that `SLOCTL_E2E_DOCKER_TEST_IMAGE` is optional, if not provided the image will be built withing the test code.