### PR TITLE
chore: Trim prefix from Docker image in Docker tests

### DIFF
--- a/test/dockertest/docker_test.go
+++ b/test/dockertest/docker_test.go
@@ -90,7 +90,7 @@ func setup(t *testing.T) {
 	t.Helper()
 	once.Do(func() {
 		if imageOverride := os.Getenv("SLOCTL_E2E_DOCKER_TEST_IMAGE"); imageOverride != "" {
-			dockerImage = imageOverride
+			dockerImage = strings.TrimPrefix(imageOverride, "v")
 			t.Log("Using sloctl image override:", dockerImage)
 			return
 		}


### PR DESCRIPTION
## Motivation

We're using `github.ref_name` which is the literal tag name, when passed as the image tag it results in:

```
Unable to find image 'nobl9/sloctl:v0.3.2' locally
```

We need to trim this `v` prefix in order for it to work.
Since there's no easy way to do that in the workflow itself (because we're using reusable workflow), we need to trim it in the test code.