### PR TITLE
fix: Remove replace clause

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
-  skip-dirs:
-    - scripts
   skip-dirs-use-default: true
 
 issues:
@@ -24,6 +22,8 @@ issues:
     - linters:
         - revive
       text: "error-strings: error strings should not be capitalized or end with punctuation or a newline"
+  exclude-dirs:
+    - scripts
   # Value 0 means show all.
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.22
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0
-	github.com/goccy/go-yaml v1.11.3
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/nobl9/nobl9-go v0.83.0-rc2
+	github.com/nobl9/go-yaml v1.0.1
+	github.com/nobl9/nobl9-go v0.83.0-rc3
 	github.com/pkg/errors v0.9.1
 	github.com/schollz/progressbar/v3 v3.14.4
 	github.com/spf13/cobra v1.8.1
@@ -18,7 +18,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/MicahParks/jwkset v0.5.18 // indirect
 	github.com/MicahParks/keyfunc/v3 v3.3.3 // indirect
-	github.com/aws/aws-sdk-go v1.54.9 // indirect
+	github.com/aws/aws-sdk-go v1.54.15 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.17.0 // indirect
@@ -48,5 +48,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/goccy/go-yaml => github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/MicahParks/jwkset v0.5.18 h1:WLdyMngF7rCrnstQxA7mpRoxeaWqGzPM/0z40PJU
 github.com/MicahParks/jwkset v0.5.18/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
 github.com/MicahParks/keyfunc/v3 v3.3.3 h1:c6j9oSu1YUo0k//KwF1miIQlEMtqNlj7XBFLB8jtEmY=
 github.com/MicahParks/keyfunc/v3 v3.3.3/go.mod h1:f/UMyXdKfkZzmBeBFUeYk+zu066J1Fcl48f7Wnl5Z48=
-github.com/aws/aws-sdk-go v1.54.9 h1:e0Czh9AhrCVPuyaIUnibYmih3cYexJKlqlHSJ2eMKbI=
-github.com/aws/aws-sdk-go v1.54.9/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.54.15 h1:ErgCEVbzuSfuZl9nR+g8FFnzjgeJ/AqAGOEWn6tgAHo=
+github.com/aws/aws-sdk-go v1.54.15/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -51,10 +51,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9 h1:HWAY7k8zA8T3dgQRg6llwyWshguD6bIeaVXukNrnen4=
-github.com/nobl9/go-yaml v0.0.0-20240626115914-6b82fd0d61b9/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
-github.com/nobl9/nobl9-go v0.83.0-rc2 h1:acT1a65CFs3Yr3IKR2mGu/uZR5ANLuy6MNkvSf8nyUU=
-github.com/nobl9/nobl9-go v0.83.0-rc2/go.mod h1:2Epdo9dnAawXrQV7ZTdFnItJjw89zdsmaW5icPrqduw=
+github.com/nobl9/go-yaml v1.0.1 h1:Aj1kSaYdRQTKlvS6ihvXzQJhCpoHhtf9nfA95zqWH4Q=
+github.com/nobl9/go-yaml v1.0.1/go.mod h1:t7vCO8ctYdBweZxU5lUgxzAw31+ZcqJYeqRtrv+5RHI=
+github.com/nobl9/nobl9-go v0.83.0-rc3 h1:OBfsIJHSFtCNDeBtG/+Y9pXTQaJLyN/z76ev1ancGE8=
+github.com/nobl9/nobl9-go v0.83.0-rc3/go.mod h1:G12D4FH2susqMH25H4zmx+FSA3JT5gu1vzP5156v1Do=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/goccy/go-yaml"
+	"github.com/nobl9/go-yaml"
 	"github.com/nobl9/nobl9-go/manifest"
 	"github.com/nobl9/nobl9-go/sdk"
 

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/goccy/go-yaml"
 	"github.com/mitchellh/colorstring"
+	"github.com/nobl9/go-yaml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"


### PR DESCRIPTION
## Motivation

The `replace` clause in `go.mod` was causing `go install` to fail with:

```
go install [github.com/nobl9/sloctl/cmd/sloctl@latest](http://github.com/nobl9/sloctl/cmd/sloctl@latest)
go: downloading [github.com/nobl9/sloctl](http://github.com/nobl9/sloctl) v0.3.2
go: [github.com/nobl9/sloctl/cmd/sloctl@latest](http://github.com/nobl9/sloctl/cmd/sloctl@latest) (in [github.com/nobl9/sloctl@v0.3.2](http://github.com/nobl9/sloctl@v0.3.2)):
    The go.mod file for the module providing named packages contains one or
    more replace directives. It must not contain directives that would cause
```

## Related changes

- https://github.com/nobl9/nobl9-go/pull/482

## Release Notes

Fixed `go install` malfunction introduced in `v0.3.2` caused by `replace` clause in `go.mod`.

