### PR TITLE
chore: Correct string replacement in Docker e2e tests

### DIFF
--- a/test/dockertest/docker_test.go
+++ b/test/dockertest/docker_test.go
@@ -90,7 +90,7 @@ func setup(t *testing.T) {
 	t.Helper()
 	once.Do(func() {
 		if imageOverride := os.Getenv("SLOCTL_E2E_DOCKER_TEST_IMAGE"); imageOverride != "" {
-			dockerImage = strings.TrimPrefix(imageOverride, "v")
+			dockerImage = strings.Replace(imageOverride, ":v", ":", 1)
 			t.Log("Using sloctl image override:", dockerImage)
 			return
 		}


### PR DESCRIPTION
We need to replace the string instead of trimming prefix as we receive the whole image not just the tag.

## Testing

```shell
SLOCTL_E2E_DOCKER_TEST_IMAGE=nobl9/sloctl:v0.3.3 make test/go/e2e-docker
```