### PR TITLE
chore: Separate stderr from stdout in the tests

### DIFF
--- a/test/apply-and-delete.bats
+++ b/test/apply-and-delete.bats
@@ -3,210 +3,212 @@
 
 # setup is run before each test.
 setup() {
-	load "test_helper/load"
-	load_lib "bats-assert"
+  load "test_helper/load"
+  load_lib "bats-assert"
 
-	generate_inputs "$BATS_TEST_TMPDIR"
+  generate_inputs "$BATS_TEST_TMPDIR"
 }
 
 @test "read separate documents from file" {
-	input="${TEST_INPUTS}/separate-documents.yaml"
+  input="${TEST_INPUTS}/separate-documents.yaml"
 
-	# apply
-	run_sloctl apply -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "$input"
+  assert_success
+  assert_output - <<EOF
 Applying 3 objects from the following sources:
  - $input
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "$input")"
+  assert_applied "$(read_files "$input")"
 
-	# delete
-	run_sloctl delete -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "$input"
+  assert_success
+  assert_output - <<EOF
 Deleting 3 objects from the following sources:
  - $input
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "$input")"
+  assert_deleted "$(read_files "$input")"
 }
 
 @test "read list of objects from file" {
-	input="${TEST_INPUTS}/list-of-objects.yaml"
+  input="${TEST_INPUTS}/list-of-objects.yaml"
 
-	# apply
-	run_sloctl apply -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "$input"
+  assert_success
+  assert_output - <<EOF
 Applying 3 objects from the following sources:
  - $input
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "$input")"
+  assert_applied "$(read_files "$input")"
 
-	# delete
-	run_sloctl delete -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "$input"
+  assert_success
+  assert_output - <<EOF
 Deleting 3 objects from the following sources:
  - $input
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "$input")"
+  assert_deleted "$(read_files "$input")"
 }
 
 @test "read single object from file" {
-	input="${TEST_INPUTS}/single-object.yaml"
+  input="${TEST_INPUTS}/single-object.yaml"
 
-	# apply
-	run_sloctl apply -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "$input"
+  assert_success
+  assert_output - <<EOF
 Applying 1 objects from the following sources:
  - $input
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "$input")"
+  assert_applied "$(read_files "$input")"
 
-	# delete
-	run_sloctl delete -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "$input"
+  assert_success
+  assert_output - <<EOF
 Deleting 1 objects from the following sources:
  - $input
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "$input")"
+  assert_deleted "$(read_files "$input")"
 }
 
 @test "read from stdin" {
-	input="${TEST_INPUTS}/single-object.yaml"
+  input="${TEST_INPUTS}/single-object.yaml"
 
-	# apply
-	run_sloctl apply -f - <"$input"
-	assert_success
-	assert_output "The resources were successfully applied."
-	assert_applied "$(read_files "$input")"
+  # apply
+  run_sloctl apply -f - <"$input"
+  assert_success
+  assert_output "The resources were successfully applied."
+  assert_applied "$(read_files "$input")"
 
-	# delete
-	run_sloctl delete -f - <"$input"
-	assert_success
-	assert_output "The resources were successfully deleted."
-	assert_deleted "$(read_files "$input")"
+  # delete
+  run_sloctl delete -f - <"$input"
+  assert_success
+  assert_output "The resources were successfully deleted."
+  assert_deleted "$(read_files "$input")"
 }
 
 @test "project flag differs from file definition -> error" {
-	# These changes won't (or at least shouldn't) take any effect.
-	# To make it easier to test the output we use the static names, without the generated hash.
-	input="${TEST_SUITE_INPUTS}/$(basename "$BATS_TEST_FILENAME" .bats)/project-flag-differs.yaml"
+  # These changes won't (or at least shouldn't) take any effect.
+  # To make it easier to test the output we use the static names, without the generated hash.
+  input="${TEST_SUITE_INPUTS}/$(basename "$BATS_TEST_FILENAME" .bats)/project-flag-differs.yaml"
 
-	project_flag_mismatch_project="kamino"
-	# Prefer multiline string over heredoc since this is a one liner, this way we keep it somewhat readable.
-	project_flag_mismatch_error="Error: \
+  project_flag_mismatch_project="kamino"
+  # Prefer multiline string over heredoc since this is a one liner, this way we keep it somewhat readable.
+  project_flag_mismatch_error="Error: \
 The death-star project from the provided object destroyer.death-star \
 does not match the project '$project_flag_mismatch_project'. \
 You must pass '--project=death-star' to perform this operation or \
 allow the Project to be inferred from the object definition."
 
-	# apply
-	run_sloctl apply -f "$input" -p "$project_flag_mismatch_project"
-	assert_failure
-	assert_output "$project_flag_mismatch_error"
+  # apply
+  run_sloctl apply -f "$input" -p "$project_flag_mismatch_project"
+  assert_failure
+  output="$stderr"
+  assert_output "$project_flag_mismatch_error"
 
-	# delete
-	run_sloctl apply -f "$input" -p "$project_flag_mismatch_project"
-	assert_failure
-	assert_output "$project_flag_mismatch_error"
+  # delete
+  run_sloctl apply -f "$input" -p "$project_flag_mismatch_project"
+  assert_failure
+  output="$stderr"
+  assert_output "$project_flag_mismatch_error"
 }
 
 @test "read from json file" {
-	input="${TEST_INPUTS}/single-object.json"
+  input="${TEST_INPUTS}/single-object.json"
 
-	# apply
-	run_sloctl apply -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "$input"
+  assert_success
+  assert_output - <<EOF
 Applying 1 objects from the following sources:
  - $input
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "$input")"
+  assert_applied "$(read_files "$input")"
 
-	# delete
-	run_sloctl delete -f "$input"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "$input"
+  assert_success
+  assert_output - <<EOF
 Deleting 1 objects from the following sources:
  - $input
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "$input")"
+  assert_deleted "$(read_files "$input")"
 }
 
 @test "read from multiple sources" {
-	inputs_base="$TEST_INPUTS/recursive"
-	inputs=(
-		"$inputs_base/first-level.yaml"
-		"$inputs_base/nested/nested/third-level.json"
-		"$inputs_base/nested/second-level.yml"
-	)
+  inputs_base="$TEST_INPUTS/recursive"
+  inputs=(
+    "$inputs_base/first-level.yaml"
+    "$inputs_base/nested/nested/third-level.json"
+    "$inputs_base/nested/second-level.yml"
+  )
 
-	# apply
-	run_sloctl apply -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
+  assert_success
+  assert_output - <<EOF
 Applying 4 objects from the following sources:
  - ${inputs[0]}
  - ${inputs[1]}
  - ${inputs[2]}
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "${inputs[@]}")"
+  assert_applied "$(read_files "${inputs[@]}")"
 
-	# delete
-	run_sloctl delete -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
+  assert_success
+  assert_output - <<EOF
 Deleting 4 objects from the following sources:
  - ${inputs[0]}
  - ${inputs[1]}
  - ${inputs[2]}
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "${inputs[@]}")"
+  assert_deleted "$(read_files "${inputs[@]}")"
 }
 
 @test "recursive directory read with **" {
-	inputs_base="$TEST_INPUTS/recursive"
-	inputs=(
-		"$inputs_base/first-level.yaml"
-		"$inputs_base/nested/nested/third-level.json"
-		"$inputs_base/nested/second-level.yml"
-	)
+  inputs_base="$TEST_INPUTS/recursive"
+  inputs=(
+    "$inputs_base/first-level.yaml"
+    "$inputs_base/nested/nested/third-level.json"
+    "$inputs_base/nested/second-level.yml"
+  )
 
-	# apply
-	run_sloctl apply -f "'$inputs_base/**'"
-	assert_success
-	assert_output - <<EOF
+  # apply
+  run_sloctl apply -f "'$inputs_base/**'"
+  assert_success
+  assert_output - <<EOF
 Applying 4 objects from the following sources:
  - ${inputs[0]}
  - ${inputs[1]}
  - ${inputs[2]}
 The resources were successfully applied.
 EOF
-	assert_applied "$(read_files "${inputs[@]}")"
+  assert_applied "$(read_files "${inputs[@]}")"
 
-	# delete
-	run_sloctl delete -f "'$inputs_base/**'"
-	assert_success
-	assert_output - <<EOF
+  # delete
+  run_sloctl delete -f "'$inputs_base/**'"
+  assert_success
+  assert_output - <<EOF
 Deleting 4 objects from the following sources:
  - ${inputs[0]}
  - ${inputs[1]}
  - ${inputs[2]}
 The resources were successfully deleted.
 EOF
-	assert_deleted "$(read_files "${inputs[@]}")"
+  assert_deleted "$(read_files "${inputs[@]}")"
 }

--- a/test/delete-by-name.bats
+++ b/test/delete-by-name.bats
@@ -3,24 +3,24 @@
 
 # setup_file is run only once for the whole file.
 setup_file() {
-	load "test_helper/load"
-	load_lib "bats-assert"
+  load "test_helper/load"
+  load_lib "bats-assert"
 
-	generate_inputs "$BATS_FILE_TMPDIR"
-	run_sloctl apply -f "'$TEST_INPUTS/**'"
-	assert_success
+  generate_inputs "$BATS_FILE_TMPDIR"
+  run_sloctl apply -f "'$TEST_INPUTS/**'"
+  assert_success
 }
 
 # teardown_file is run only once for the whole file.
 teardown_file() {
-	run_sloctl delete -f "'$TEST_INPUTS/**'"
+  run_sloctl delete -f "'$TEST_INPUTS/**'"
 }
 
 # setup is run before each test.
 setup() {
-	load "test_helper/load"
-	load_lib "bats-support"
-	load_lib "bats-assert"
+  load "test_helper/load"
+  load_lib "bats-support"
+  load_lib "bats-assert"
 }
 
 # -------------------------------------------------------------
@@ -31,47 +31,47 @@ setup() {
 # -------------------------------------------------------------
 
 @test "alert silence" {
-	test_delete_by_name "AlertSilence" "${TEST_INPUTS}/alertsilence.yaml"
+  test_delete_by_name "AlertSilence" "${TEST_INPUTS}/alertsilence.yaml"
 }
 
 @test "annotation" {
-	test_delete_by_name "Annotation" "${TEST_INPUTS}/annotation.yaml"
+  test_delete_by_name "Annotation" "${TEST_INPUTS}/annotation.yaml"
 }
 
 @test "slo" {
-	test_delete_by_name "SLO" "${TEST_INPUTS}/slo.yaml"
+  test_delete_by_name "SLO" "${TEST_INPUTS}/slo.yaml"
 }
 
 @test "alert policy" {
-	test_delete_by_name "AlertPolicy" "${TEST_INPUTS}/alertpolicy.yaml"
+  test_delete_by_name "AlertPolicy" "${TEST_INPUTS}/alertpolicy.yaml"
 }
 
 @test "alert method" {
-	test_delete_by_name "AlertMethod" "${TEST_INPUTS}/alertmethod.yaml"
+  test_delete_by_name "AlertMethod" "${TEST_INPUTS}/alertmethod.yaml"
 }
 
 @test "agent" {
-	test_delete_by_name "Agent" "${TEST_INPUTS}/agent.yaml"
+  test_delete_by_name "Agent" "${TEST_INPUTS}/agent.yaml"
 }
 
 @test "direct" {
-	test_delete_by_name "Direct" "${TEST_INPUTS}/direct.yaml"
+  test_delete_by_name "Direct" "${TEST_INPUTS}/direct.yaml"
 }
 
 @test "service" {
-	test_delete_by_name "Service" "${TEST_INPUTS}/service.yaml"
+  test_delete_by_name "Service" "${TEST_INPUTS}/service.yaml"
 }
 
 @test "role binding" {
-	test_delete_by_name "RoleBinding" "${TEST_INPUTS}/rolebinding.yaml"
+  test_delete_by_name "RoleBinding" "${TEST_INPUTS}/rolebinding.yaml"
 }
 
 @test "project" {
-	test_delete_by_name "Project" "${TEST_INPUTS}/project.yaml"
+  test_delete_by_name "Project" "${TEST_INPUTS}/project.yaml"
 }
 
 @test "budget adjustment" {
-	test_delete_by_name "BudgetAdjustment" "${TEST_INPUTS}/budgetadjustment.yaml"
+  test_delete_by_name "BudgetAdjustment" "${TEST_INPUTS}/budgetadjustment.yaml"
 }
 
 # Currently we cannot apply user groups and DataExport has very strict
@@ -86,14 +86,15 @@ setup() {
 # }
 
 test_delete_by_name() {
-	local \
-		kind="$1" \
-		input="$2"
+  local \
+    kind="$1" \
+    input="$2"
   object_name=$(yq -r .metadata.name "$input")
 
-	# Ensure delete by name without a name doesn't pass.
-	run_sloctl delete "$kind"
-	assert_failure
+  # Ensure delete by name without a name doesn't pass.
+  run_sloctl delete "$kind"
+  assert_failure
+  output="$stderr"
   assert_output "Error: requires at least 1 arg(s), only received 0"
 
   # Delete the object by name.
@@ -101,7 +102,7 @@ test_delete_by_name() {
   if [[ $kind != "Project" ]]; then
     args+=("-p" "death-star")
   fi
-	run_sloctl "${args[@]}"
-	assert_success
-	assert_deleted "$(read_files "$input")"
+  run_sloctl "${args[@]}"
+  assert_success
+  assert_deleted "$(read_files "$input")"
 }

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -11,8 +11,9 @@
 #
 # The output of sloctl is sanitized, the trailing whitespaces,
 # if present, are removed for easier output validation.
+# Stderr is separated from stdout into $stderr and $output.
 run_sloctl() {
-	run bash -c "set -o pipefail && sloctl $* | sed 's/ *$//'"
+	run --separate-stderr bash -c "set -o pipefail && sloctl $* | sed 's/ *$//'"
 }
 
 # read_files


### PR DESCRIPTION
## Motivation

Currently, whenever `sloctl` logs something to stderr, like `Retrying` logs, it will fail the tests because `assert_output` is checking `$output` variable set by `run` function of `bats` framework. The `$output` contains both stderr and stdout. Fortunately, there's a flag for `run` --> `--separate-stderr` which does the job and separates both outputs into different variables.