### PR TITLE
chore: Update docker image to 1.22-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.18 AS builder
+FROM golang:1.22-alpine3.20 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Motivation

Resolves the issue https://nvd.nist.gov/vuln/detail/CVE-2024-24790

## Release Notes

The docker image has been updated to resolve critical level vuln in stdlib (https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
