### PR TITLE
fix: Add missing stderr from assert_success output

### DIFF
--- a/test/apply-and-delete.bats
+++ b/test/apply-and-delete.bats
@@ -14,7 +14,7 @@ setup() {
 
   # apply
   run_sloctl apply -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 3 objects from the following sources:
  - $input
@@ -24,7 +24,7 @@ EOF
 
   # delete
   run_sloctl delete -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 3 objects from the following sources:
  - $input
@@ -38,7 +38,7 @@ EOF
 
   # apply
   run_sloctl apply -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 3 objects from the following sources:
  - $input
@@ -48,7 +48,7 @@ EOF
 
   # delete
   run_sloctl delete -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 3 objects from the following sources:
  - $input
@@ -62,7 +62,7 @@ EOF
 
   # apply
   run_sloctl apply -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 1 objects from the following sources:
  - $input
@@ -72,7 +72,7 @@ EOF
 
   # delete
   run_sloctl delete -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 1 objects from the following sources:
  - $input
@@ -86,13 +86,13 @@ EOF
 
   # apply
   run_sloctl apply -f - <"$input"
-  assert_success
+  assert_success_joined_output
   assert_output "The resources were successfully applied."
   assert_applied "$(read_files "$input")"
 
   # delete
   run_sloctl delete -f - <"$input"
-  assert_success
+  assert_success_joined_output
   assert_output "The resources were successfully deleted."
   assert_deleted "$(read_files "$input")"
 }
@@ -128,7 +128,7 @@ allow the Project to be inferred from the object definition."
 
   # apply
   run_sloctl apply -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 1 objects from the following sources:
  - $input
@@ -138,7 +138,7 @@ EOF
 
   # delete
   run_sloctl delete -f "$input"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 1 objects from the following sources:
  - $input
@@ -157,7 +157,7 @@ EOF
 
   # apply
   run_sloctl apply -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 4 objects from the following sources:
  - ${inputs[0]}
@@ -169,7 +169,7 @@ EOF
 
   # delete
   run_sloctl delete -f "${inputs[0]}" -f "${inputs[1]}" -f "${inputs[2]}"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 4 objects from the following sources:
  - ${inputs[0]}
@@ -190,7 +190,7 @@ EOF
 
   # apply
   run_sloctl apply -f "'$inputs_base/**'"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Applying 4 objects from the following sources:
  - ${inputs[0]}
@@ -202,7 +202,7 @@ EOF
 
   # delete
   run_sloctl delete -f "'$inputs_base/**'"
-  assert_success
+  assert_success_joined_output
   assert_output - <<EOF
 Deleting 4 objects from the following sources:
  - ${inputs[0]}

--- a/test/aws-iam-ids.bats
+++ b/test/aws-iam-ids.bats
@@ -8,7 +8,7 @@ setup_file() {
 
 	generate_inputs "$BATS_FILE_TMPDIR"
 	run_sloctl apply -f "'$TEST_INPUTS/**'"
-	assert_success
+	assert_success_joined_output
 }
 
 # teardown_file is run only once for the whole file.
@@ -25,12 +25,12 @@ setup() {
 
 @test "dataexport" {
 	run_sloctl aws-iam-ids dataexport
-	assert_success
+	assert_success_joined_output
 	assert_output --regexp "[-a-zA-Z0-9]+"
 }
 
 @test "direct" {
 	run_sloctl aws-iam-ids direct splunk-direct
-	assert_success
+	assert_success_joined_output
 	assert_output --regexp "externalID: [-a-zA-Z0-9]+\naccountID: \"\d+\""
 }

--- a/test/delete-by-name.bats
+++ b/test/delete-by-name.bats
@@ -8,7 +8,7 @@ setup_file() {
 
   generate_inputs "$BATS_FILE_TMPDIR"
   run_sloctl apply -f "'$TEST_INPUTS/**'"
-  assert_success
+  assert_success_joined_output
 }
 
 # teardown_file is run only once for the whole file.
@@ -103,6 +103,6 @@ test_delete_by_name() {
     args+=("-p" "death-star")
   fi
   run_sloctl "${args[@]}"
-  assert_success
+  assert_success_joined_output
   assert_deleted "$(read_files "$input")"
 }

--- a/test/get.bats
+++ b/test/get.bats
@@ -8,7 +8,7 @@ setup_file() {
 
 	generate_inputs "$BATS_FILE_TMPDIR"
 	run_sloctl apply -f "'$TEST_INPUTS/**'"
-	assert_success
+	assert_success_joined_output
 
 	export TEST_OUTPUTS="$TEST_SUITE_OUTPUTS/get"
 }
@@ -93,7 +93,7 @@ setup() {
 @test "agent with keys" {
 	for flag in -k --with-keys; do
 		run_sloctl get agent -p "death-star" "$flag"
-		assert_success
+		assert_success_joined_output
 		# Assert length of client_id and regex of client_secret, as the latter may vary.
 		client_id="$(yq -r .[].metadata.client_id <<<"$output")"
 		client_secret="$(yq -r .[].metadata.client_secret <<<"$output")"
@@ -147,13 +147,13 @@ setup() {
 	verify_get_success "$output" "$want"
 
 	run_sloctl get project -l purpose=offensive hoth-base
-	assert_success
+	assert_success_joined_output
 	assert_output "No resources found."
 }
 
 @test "check full alert policy output" {
 	run_sloctl get alertpolicy -p death-star trigger-alert-immediately
-	assert_success
+	assert_success_joined_output
 	assert_equal \
 		"$(yq --sort-keys -y -r . <<<"$output")" \
 		"$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/alertpolicy.yaml")"
@@ -161,7 +161,7 @@ setup() {
 
 @test "check full direct output" {
 	run_sloctl get direct -p death-star splunk-direct
-	assert_success
+	assert_success_joined_output
 	assert_equal \
 		"$(yq --sort-keys -y -r . <<<"$output")" \
 		"$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/direct.yaml")"
@@ -181,7 +181,7 @@ test_get() {
 		# org limits making it impossible to test with applied objects.
 		if [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "DataExport" ]]; then
 			run_sloctl get "$alias" -A
-			assert_success
+			assert_success_joined_output
 			refute_output --partial "Available Commands:"
 
 			continue
@@ -215,17 +215,17 @@ test_get() {
 	for alias in "${aliases[@]}"; do
 		if [[ "$kind" == "Project" ]] || [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "BudgetAdjustment" ]]; then
 			run_sloctl get "$alias" "fake-name-123-321"
-			assert_success
+			assert_success_joined_output
 			assert_output "No resources found."
 
 			continue
 		fi
 
 		run_sloctl get "$alias" "fake-name-123-321"
-		assert_success
+		assert_success_joined_output
 		assert_output "No resources found in 'default' project."
 		run_sloctl get "$alias" -p "fake-project-123-321"
-		assert_success
+		assert_success_joined_output
 		assert_output "No resources found in 'fake-project-123-321' project."
 	done
 }
@@ -234,7 +234,7 @@ verify_get_success() {
 	local \
 		have="$1" \
 		want="$2"
-	assert_success
+	assert_success_joined_output
 	# Since cobra does not return errors on unknown subcommands (https://github.com/spf13/cobra/issues/706)
 	# we need to hack our way around it.
 	refute_output --partial "Available Commands:"

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -229,7 +229,7 @@ ensure_installed() {
 }
 
 # load_lib
-# ================
+# ========
 #
 # Summary: Load a given bats library.
 #
@@ -240,4 +240,19 @@ ensure_installed() {
 load_lib() {
   local name="$1"
   load "/usr/lib/bats/${name}/load.bash"
+}
+
+# assert_success_joined_output
+# ============================
+#
+# Summary: Assert success of command.
+#
+# Usage: assert_success_joined_output
+#
+# In case erroroneus code is detected, both stderr and stdout are conjoined.
+# This is neccessary due to `run --separate-stderr` usage.
+# Otherwise, only stdout is printed which is not very useful.
+assert_success_joined_output() {
+  output+="
+$stderr" assert_success
 }


### PR DESCRIPTION
Since we introduced `run --separate-stderr` flag some time ago in order to avoid `assert_output` checking both stdout and stderr (which can contain stuff like "retrying" notices) and failing due to that, it had a side effect on `assert_success`, which now only prints `$output` which is only stdout (stderr is separated into `$stderr`).

To fix that we need to give `assert_success` conjoined stdout and stderr.