### PR TITLE
feat: Improve flags handling [PC-13534]

### DIFF
--- a/.github/workflows/e2e-tests-dispatch.yml
+++ b/.github/workflows/e2e-tests-dispatch.yml
@@ -22,6 +22,7 @@ on:
         description: Makefile test target to run
         required: false
         type: string
+        default: test/e2e
       sloctlImage:
         description: >
           Sloctl docker image to use for e2e docker image tests.

--- a/internal/apply.go
+++ b/internal/apply.go
@@ -19,6 +19,7 @@ type ApplyCmd struct {
 	autoConfirm       bool
 	replay            bool
 	replayFrom        TimeValue
+	project           string
 }
 
 //go:embed apply_example.sh
@@ -37,19 +38,20 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 		Args:    positionalArgsCondition,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			apply.client = r.GetClient()
-			if r.Flags.Project != "" {
+			if apply.project != "" {
 				apply.projectFlagWasSet = true
 			}
 			if apply.dryRun {
-				NotifyDryRunFlag()
+				notifyDryRunFlag()
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error { return apply.Run(cmd) },
 	}
 
-	RegisterFileFlag(cmd, true, &apply.definitionPaths)
-	RegisterDryRunFlag(cmd, &apply.dryRun)
-	RegisterAutoConfirmationFlag(cmd, &apply.autoConfirm)
+	registerFileFlag(cmd, true, &apply.definitionPaths)
+	registerDryRunFlag(cmd, &apply.dryRun)
+	registerAutoConfirmationFlag(cmd, &apply.autoConfirm)
+	registerProjectFlag(cmd, &apply.project)
 
 	const (
 		replayFlagName     = "replay"

--- a/internal/apply.go
+++ b/internal/apply.go
@@ -40,6 +40,7 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 			apply.client = r.GetClient()
 			if apply.project != "" {
 				apply.projectFlagWasSet = true
+				apply.client.Config.Project = apply.project
 			}
 			if apply.dryRun {
 				notifyDryRunFlag()

--- a/internal/aws_iam_ids.go
+++ b/internal/aws_iam_ids.go
@@ -34,7 +34,7 @@ func (r *RootCmd) NewAwsIamIds() *cobra.Command {
 		PersistentPreRun: func(iamIdsCmd *cobra.Command, args []string) { awsIamIds.client = r.GetClient() },
 		RunE:             func(iamIdsCmd *cobra.Command, args []string) error { return awsIamIds.Direct(iamIdsCmd) },
 	}
-	RegisterOutputFormatFlags(direct, &awsIamIds.outputFormat, &awsIamIds.fieldSeparator, &awsIamIds.recordSeparator)
+	registerOutputFormatFlags(direct, &awsIamIds.outputFormat, &awsIamIds.fieldSeparator, &awsIamIds.recordSeparator)
 	cobraCmd.AddCommand(direct)
 
 	dataExport := &cobra.Command{

--- a/internal/config.go
+++ b/internal/config.go
@@ -292,7 +292,7 @@ func (c *ConfigCmd) CurrentContextCommand() *cobra.Command {
 		},
 	}
 
-	RegisterVerboseFlag(currentCtxCmd, &c.verbose)
+	registerVerboseFlag(currentCtxCmd, &c.verbose)
 
 	return currentCtxCmd
 }
@@ -331,7 +331,7 @@ func (c *ConfigCmd) GetContextsCommand() *cobra.Command {
 		},
 	}
 
-	RegisterVerboseFlag(getContextsCmd, &c.verbose)
+	registerVerboseFlag(getContextsCmd, &c.verbose)
 
 	return getContextsCmd
 }

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -51,6 +51,7 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	registerFileFlag(cmd, false, &deleteCmd.definitionPaths)
 	registerDryRunFlag(cmd, &deleteCmd.dryRun)
 	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
+	registerProjectFlag(cmd, &deleteCmd.project)
 
 	// register all subcommands for delete
 	for _, def := range []struct {
@@ -75,9 +76,6 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	} {
 		if len(def.plural) == 0 {
 			def.plural = def.kind.String() + "s"
-		}
-		if objectKindSupportsProjectFlag(def.kind) {
-			registerProjectFlag(cmd, &deleteCmd.project)
 		}
 		cmd.AddCommand(newSubcommand(
 			deleteCmd,
@@ -128,6 +126,9 @@ func newSubcommand(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSubcommand(cmd.Context(), deleteCmd, kind, args)
 		},
+	}
+	if objectKindSupportsProjectFlag(kind) {
+		registerProjectFlag(sc, &deleteCmd.project)
 	}
 	registerDryRunFlag(sc, &deleteCmd.dryRun)
 	return sc

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -51,7 +51,6 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	registerFileFlag(cmd, false, &deleteCmd.definitionPaths)
 	registerDryRunFlag(cmd, &deleteCmd.dryRun)
 	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
-	registerProjectFlag(cmd, &deleteCmd.project)
 
 	// register all subcommands for delete
 	for _, def := range []struct {
@@ -76,6 +75,9 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	} {
 		if len(def.plural) == 0 {
 			def.plural = def.kind.String() + "s"
+		}
+		if objectKindSupportsProjectFlag(def.kind) {
+			registerProjectFlag(cmd, &deleteCmd.project)
 		}
 		cmd.AddCommand(newSubcommand(
 			deleteCmd,

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -18,6 +18,7 @@ type DeleteCmd struct {
 	definitionPaths   []string
 	dryRun            bool
 	autoConfirm       bool
+	project           string
 }
 
 //go:embed delete_example.sh
@@ -36,19 +37,21 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 		Args:    positionalArgsCondition,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			deleteCmd.client = r.GetClient()
-			if r.Flags.Project != "" {
+			if deleteCmd.project != "" {
 				deleteCmd.projectFlagWasSet = true
+				deleteCmd.client.Config.Project = deleteCmd.project
 			}
 			if deleteCmd.dryRun {
-				NotifyDryRunFlag()
+				notifyDryRunFlag()
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error { return deleteCmd.Run(cmd) },
 	}
 
-	RegisterFileFlag(cmd, false, &deleteCmd.definitionPaths)
-	RegisterDryRunFlag(cmd, &deleteCmd.dryRun)
-	RegisterAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
+	registerFileFlag(cmd, false, &deleteCmd.definitionPaths)
+	registerDryRunFlag(cmd, &deleteCmd.dryRun)
+	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
+	registerProjectFlag(cmd, &deleteCmd.project)
 
 	// register all subcommands for delete
 	for _, def := range []struct {
@@ -124,7 +127,7 @@ func newSubcommand(
 			return runSubcommand(cmd.Context(), deleteCmd, kind, args)
 		},
 	}
-	RegisterDryRunFlag(sc, &deleteCmd.dryRun)
+	registerDryRunFlag(sc, &deleteCmd.dryRun)
 	return sc
 }
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -75,12 +75,12 @@ func objectKindSupportsProjectFlag(kind manifest.Kind) bool {
 }
 
 func registerProjectFlag(cmd *cobra.Command, storeIn *string) {
-	cmd.PersistentFlags().StringVarP(storeIn, "project", "p", "",
+	cmd.Flags().StringVarP(storeIn, "project", "p", "",
 		`List the requested object(s) which belong to the specified Project (name).`)
 }
 
 func registerAllProjectsFlag(cmd *cobra.Command, storeIn *bool) {
-	cmd.PersistentFlags().BoolVarP(storeIn, "all-projects", "A", false,
+	cmd.Flags().BoolVarP(storeIn, "all-projects", "A", false,
 		`List the requested object(s) across all projects.`)
 }
 
@@ -97,6 +97,6 @@ func objectKindSupportsLabelsFlag(kind manifest.Kind) bool {
 }
 
 func registerLabelsFlag(cmd *cobra.Command, storeIn *[]string) {
-	cmd.PersistentFlags().StringArrayVarP(storeIn, "label", "l", []string{},
+	cmd.Flags().StringArrayVarP(storeIn, "label", "l", []string{},
 		`Filter resource by label. Example: key=value,key2=value2,key2=value3.`)
 }

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nobl9/nobl9-go/manifest"
+
 	"github.com/nobl9/sloctl/internal/csv"
 )
 
@@ -14,11 +16,11 @@ const (
 	flagDryRun = "dry-run"
 )
 
-func NotifyDryRunFlag() {
+func notifyDryRunFlag() {
 	_, _ = fmt.Fprintln(os.Stderr, "Running in dry run mode, changes will not be applied.")
 }
 
-func RegisterFileFlag(cmd *cobra.Command, required bool, storeIn *[]string) {
+func registerFileFlag(cmd *cobra.Command, required bool, storeIn *[]string) {
 	cmd.Flags().StringArrayVarP(storeIn, flagFile, "f", []string{},
 		"File path, glob pattern or a URL to the configuration in YAML or JSON format."+
 			" This option can be used multiple times.")
@@ -27,23 +29,23 @@ func RegisterFileFlag(cmd *cobra.Command, required bool, storeIn *[]string) {
 	}
 }
 
-func RegisterDryRunFlag(cmd *cobra.Command, storeIn *bool) {
+func registerDryRunFlag(cmd *cobra.Command, storeIn *bool) {
 	cmd.Flags().BoolVarP(storeIn, flagDryRun, "", false,
 		"Submit server-side request without persisting the configured resources.")
 }
 
-func RegisterVerboseFlag(cmd *cobra.Command, storeIn *bool) {
+func registerVerboseFlag(cmd *cobra.Command, storeIn *bool) {
 	cmd.Flags().BoolVarP(storeIn, "verbose", "v", false,
 		"Display verbose information about configuration")
 }
 
-func RegisterAutoConfirmationFlag(cmd *cobra.Command, storeIn *bool) {
+func registerAutoConfirmationFlag(cmd *cobra.Command, storeIn *bool) {
 	cmd.Flags().BoolVarP(storeIn, "yes", "y", false,
 		"Auto confirm files threshold prompt."+
 			" Threshold can be changed or disabled in config.toml or via env variables.")
 }
 
-func RegisterOutputFormatFlags(cmd *cobra.Command, outputFormat, fieldSeparator, recordSeparator *string) {
+func registerOutputFormatFlags(cmd *cobra.Command, outputFormat, fieldSeparator, recordSeparator *string) {
 	cmd.PersistentFlags().StringVarP(outputFormat, "output", "o", "yaml",
 		`Output format: one of yaml|json|csv.`)
 
@@ -52,4 +54,49 @@ func RegisterOutputFormatFlags(cmd *cobra.Command, outputFormat, fieldSeparator,
 
 	cmd.PersistentFlags().StringVarP(recordSeparator, csv.RecordSeparatorFlag, "",
 		csv.DefaultRecordSeparator, "Record Separator for CSV.")
+}
+
+var projectFlagSupportingKinds = map[manifest.Kind]struct{}{
+	manifest.KindSLO:          {},
+	manifest.KindService:      {},
+	manifest.KindAgent:        {},
+	manifest.KindAlertPolicy:  {},
+	manifest.KindAlertSilence: {},
+	manifest.KindAlertMethod:  {},
+	manifest.KindDirect:       {},
+	manifest.KindDataExport:   {},
+	manifest.KindRoleBinding:  {},
+	manifest.KindAnnotation:   {},
+}
+
+func objectKindSupportsProjectFlag(kind manifest.Kind) bool {
+	_, ok := projectFlagSupportingKinds[kind]
+	return ok
+}
+
+func registerProjectFlag(cmd *cobra.Command, storeIn *string) {
+	cmd.PersistentFlags().StringVarP(storeIn, "project", "p", "",
+		`List the requested object(s) which belong to the specified Project (name).`)
+}
+
+func registerAllProjectsFlag(cmd *cobra.Command, storeIn *bool) {
+	cmd.PersistentFlags().BoolVarP(storeIn, "all-projects", "A", false,
+		`List the requested object(s) across all projects.`)
+}
+
+var labelSupportingKinds = map[manifest.Kind]struct{}{
+	manifest.KindProject:     {},
+	manifest.KindService:     {},
+	manifest.KindSLO:         {},
+	manifest.KindAlertPolicy: {},
+}
+
+func objectKindSupportsLabelsFlag(kind manifest.Kind) bool {
+	_, ok := labelSupportingKinds[kind]
+	return ok
+}
+
+func registerLabelsFlag(cmd *cobra.Command, storeIn *[]string) {
+	cmd.PersistentFlags().StringArrayVarP(storeIn, "label", "l", []string{},
+		`Filter resource by label. Example: key=value,key2=value2,key2=value3.`)
 }

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -60,7 +60,7 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 		RunE:             func(cmd *cobra.Command, args []string) error { return replay.Run(cmd) },
 	}
 
-	RegisterFileFlag(cmd, false, &replay.configPaths)
+	registerFileFlag(cmd, false, &replay.configPaths)
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
 	return cmd

--- a/internal/root.go
+++ b/internal/root.go
@@ -25,8 +25,6 @@ func Execute() {
 type globalFlags struct {
 	ConfigFile   string
 	Context      string
-	Project      string
-	AllProjects  bool
 	NoConfigFile bool
 }
 
@@ -46,10 +44,6 @@ For every command more detailed help is available.`,
 	rootCmd.PersistentFlags().StringVar(&root.Flags.ConfigFile, "config", "", "Config file path.")
 	rootCmd.PersistentFlags().StringVarP(&root.Flags.Context, "context", "c", "",
 		`Overrides the default context for the duration of the selected command.`)
-	rootCmd.PersistentFlags().StringVarP(&root.Flags.Project, "project", "p", "",
-		`Overrides the default project from active Delete for the duration of the selected command.`)
-	rootCmd.PersistentFlags().BoolVarP(&root.Flags.AllProjects, "all-projects", "A", false,
-		`Displays the objects from all of the projects.`)
 	rootCmd.PersistentFlags().BoolVarP(&root.Flags.NoConfigFile, "no-config-file", "", false,
 		`Don't create config.toml, operate only on env variables.`)
 
@@ -91,11 +85,6 @@ func (r *RootCmd) setupClient() error {
 	conf, err := sdk.ReadConfig(options...)
 	if err != nil {
 		return err
-	}
-	if r.Flags.AllProjects {
-		conf.Project = "*"
-	} else if r.Flags.Project != "" {
-		conf.Project = r.Flags.Project
 	}
 	r.Client, err = sdk.NewClient(conf)
 	if err != nil {

--- a/test/delete-by-name.bats
+++ b/test/delete-by-name.bats
@@ -99,7 +99,7 @@ test_delete_by_name() {
 
   # Delete the object by name.
   args=(delete "$kind" "$object_name")
-  if [[ $kind != "Project" ]]; then
+  if [[ $kind != "Project" ]] && [[ $kind != "BudgetAdjustment" ]]; then
     args+=("-p" "death-star")
   fi
   run_sloctl "${args[@]}"

--- a/test/get.bats
+++ b/test/get.bats
@@ -3,244 +3,244 @@
 
 # setup_file is run only once for the whole file.
 setup_file() {
-	load "test_helper/load"
-	load_lib "bats-assert"
+  load "test_helper/load"
+  load_lib "bats-assert"
 
-	generate_inputs "$BATS_FILE_TMPDIR"
-	run_sloctl apply -f "'$TEST_INPUTS/**'"
-	assert_success_joined_output
+  generate_inputs "$BATS_FILE_TMPDIR"
+  run_sloctl apply -f "'$TEST_INPUTS/**'"
+  assert_success_joined_output
 
-	export TEST_OUTPUTS="$TEST_SUITE_OUTPUTS/get"
+  export TEST_OUTPUTS="$TEST_SUITE_OUTPUTS/get"
 }
 
 # teardown_file is run only once for the whole file.
 teardown_file() {
-	run_sloctl delete -f "'$TEST_INPUTS/**'"
+  run_sloctl delete -f "'$TEST_INPUTS/**'"
 }
 
 # setup is run before each test.
 setup() {
-	load "test_helper/load"
-	load_lib "bats-support"
-	load_lib "bats-assert"
+  load "test_helper/load"
+  load_lib "bats-support"
+  load_lib "bats-assert"
 }
 
 @test "alert methods" {
-	aliases="alertmethod alertmethods"
-	test_get "AlertMethod" "$aliases" "${TEST_INPUTS}/alertmethods.yaml" "$output"
+  aliases="alertmethod alertmethods"
+  test_get "AlertMethod" "$aliases" "${TEST_INPUTS}/alertmethods.yaml" "$output"
 }
 
 @test "alert policies" {
-	aliases="alertpolicy alertpolicies"
-	test_get "AlertPolicy" "$aliases" "${TEST_INPUTS}/alertpolicies.yaml" "$output"
+  aliases="alertpolicy alertpolicies"
+  test_get "AlertPolicy" "$aliases" "${TEST_INPUTS}/alertpolicies.yaml" "$output"
 }
 
 @test "alert silences" {
-	aliases="alertsilence alertsilences"
-	test_get "AlertSilence" "$aliases" "${TEST_INPUTS}/alertsilences.yaml" "$output"
+  aliases="alertsilence alertsilences"
+  test_get "AlertSilence" "$aliases" "${TEST_INPUTS}/alertsilences.yaml" "$output"
 }
 
 @test "annotations" {
-	aliases="annotation annotations"
-	test_get "Annotation" "$aliases" "${TEST_INPUTS}/annotations.yaml" "$output"
+  aliases="annotation annotations"
+  test_get "Annotation" "$aliases" "${TEST_INPUTS}/annotations.yaml" "$output"
 }
 
 @test "data exports" {
-	aliases="dataexport dataexports"
-	test_get "DataExport" "$aliases" "" "$output"
+  aliases="dataexport dataexports"
+  test_get "DataExport" "$aliases" "" "$output"
 }
 
 @test "directs" {
-	aliases="direct directs"
-	test_get "Direct" "$aliases" "${TEST_INPUTS}/directs.yaml" "$output"
+  aliases="direct directs"
+  test_get "Direct" "$aliases" "${TEST_INPUTS}/directs.yaml" "$output"
 }
 
 @test "user groups" {
-	aliases="usergroup usergroups"
-	test_get "UserGroup" "$aliases" "" "$output"
+  aliases="usergroup usergroups"
+  test_get "UserGroup" "$aliases" "" "$output"
 }
 
 @test "projects" {
-	aliases="projects project"
-	test_get "Project" "$aliases" "${TEST_INPUTS}/projects.yaml" "$output"
+  aliases="projects project"
+  test_get "Project" "$aliases" "${TEST_INPUTS}/projects.yaml" "$output"
 }
 
 @test "role bindings" {
-	aliases="rolebinding rolebindings"
-	test_get "RoleBinding" "$aliases" "${TEST_INPUTS}/rolebindings.yaml" "$output"
+  aliases="rolebinding rolebindings"
+  test_get "RoleBinding" "$aliases" "${TEST_INPUTS}/rolebindings.yaml" "$output"
 }
 
 @test "services" {
-	aliases="services svc svcs service"
-	test_get "Service" "$aliases" "${TEST_INPUTS}/services.yaml" "$output"
+  aliases="services svc svcs service"
+  test_get "Service" "$aliases" "${TEST_INPUTS}/services.yaml" "$output"
 }
 
 @test "slos" {
-	aliases="slo slos"
-	test_get "SLO" "$aliases" "${TEST_INPUTS}/slos.yaml" "$output"
+  aliases="slo slos"
+  test_get "SLO" "$aliases" "${TEST_INPUTS}/slos.yaml" "$output"
 }
 
 @test "budget adjustments" {
-	aliases="budgetadjustment budgetadjustments"
-	test_get "BudgetAdjustment" "$aliases" "${TEST_INPUTS}/budgetadjustments.yaml" "$output"
+  aliases="budgetadjustment budgetadjustments"
+  test_get "BudgetAdjustment" "$aliases" "${TEST_INPUTS}/budgetadjustments.yaml" "$output"
 }
 
 @test "agent" {
-	aliases="agent agents"
-	test_get "Agent" "$aliases" "${TEST_INPUTS}/agent.yaml" "$output"
+  aliases="agent agents"
+  test_get "Agent" "$aliases" "${TEST_INPUTS}/agent.yaml" "$output"
 }
 
 @test "agent with keys" {
-	for flag in -k --with-keys; do
-		run_sloctl get agent -p "death-star" "$flag"
-		assert_success_joined_output
-		# Assert length of client_id and regex of client_secret, as the latter may vary.
-		client_id="$(yq -r .[].metadata.client_id <<<"$output")"
-		client_secret="$(yq -r .[].metadata.client_secret <<<"$output")"
-		assert_equal "${#client_id}" 20
-		assert_regex "${#client_secret}" "[a-zA-Z0-9_-]+"
-		# Finally make sure the whole Agent definition is being presented.
-		verify_get_success "$output" "$(read_files "${TEST_INPUTS}/agent.yaml")"
-	done
+  for flag in -k --with-keys; do
+    run_sloctl get agent -p "death-star" "$flag"
+    assert_success_joined_output
+    # Assert length of client_id and regex of client_secret, as the latter may vary.
+    client_id="$(yq -r .[].metadata.client_id <<<"$output")"
+    client_secret="$(yq -r .[].metadata.client_secret <<<"$output")"
+    assert_equal "${#client_id}" 20
+    assert_regex "${#client_secret}" "[a-zA-Z0-9_-]+"
+    # Finally make sure the whole Agent definition is being presented.
+    verify_get_success "$output" "$(read_files "${TEST_INPUTS}/agent.yaml")"
+  done
 }
 
 @test "projects, multiple names" {
-	run_sloctl get project death-star hoth-base
-	verify_get_success "$output" "$(read_files "${TEST_INPUTS}/projects.yaml")"
+  run_sloctl get project death-star hoth-base
+  verify_get_success "$output" "$(read_files "${TEST_INPUTS}/projects.yaml")"
 }
 
 @test "projects, labels filtering, OR conditions" {
-	want=$(read_files "${TEST_INPUTS}/projects.yaml")
-	for label in \
-		"-l purpose=defensive" \
-		"-l purpose=offensive,purpose=defensive" \
-		"-l purpose=defensive,purpose=offensive" \
-		"-l purpose=defensive -l purpose=offensive" \
-		"-l purpose=offensive -l purpose=defensive"; do
-		run_sloctl get project "$label"
-		verify_get_success "$output" "$want"
-	done
+  want=$(read_files "${TEST_INPUTS}/projects.yaml")
+  for label in \
+    "-l purpose=defensive" \
+    "-l purpose=offensive,purpose=defensive" \
+    "-l purpose=defensive,purpose=offensive" \
+    "-l purpose=defensive -l purpose=offensive" \
+    "-l purpose=offensive -l purpose=defensive"; do
+    run_sloctl get project "$label"
+    verify_get_success "$output" "$want"
+  done
 }
 
 @test "projects, labels filtering, AND conditions" {
-	want=$(read_files "${TEST_INPUTS}/projects.yaml" | yq -r '.[] |= select(.metadata.name == "death-star")')
-	for label in \
-		"-l purpose=offensive" \
-		"-l purpose=defensive,team=vader" \
-		"-l purpose=offensive,team=vader" \
-		"-l purpose=offensive,purpose=defensive,team=sidious" \
-		"-l team=sidious,purpose=offensive,purpose=defensive" \
-		"-l team=sidious,purpose=defensive,purpose=offensive" \
-		"-l purpose=offensive -l purpose=defensive,team=sidious" \
-		"-l purpose=offensive -l team=sidious,purpose=defensive" \
-		"-l team=sidious -l purpose=offensive -l purpose=defensive" \
-		"-l purpose=defensive -l purpose=offensive -l team=sidious" \
-		"-l purpose=offensive -l purpose=defensive -l team=sidious"; do
-		run_sloctl get project "$label"
-		verify_get_success "$output" "$want"
-	done
+  want=$(read_files "${TEST_INPUTS}/projects.yaml" | yq -r '.[] |= select(.metadata.name == "death-star")')
+  for label in \
+    "-l purpose=offensive" \
+    "-l purpose=defensive,team=vader" \
+    "-l purpose=offensive,team=vader" \
+    "-l purpose=offensive,purpose=defensive,team=sidious" \
+    "-l team=sidious,purpose=offensive,purpose=defensive" \
+    "-l team=sidious,purpose=defensive,purpose=offensive" \
+    "-l purpose=offensive -l purpose=defensive,team=sidious" \
+    "-l purpose=offensive -l team=sidious,purpose=defensive" \
+    "-l team=sidious -l purpose=offensive -l purpose=defensive" \
+    "-l purpose=defensive -l purpose=offensive -l team=sidious" \
+    "-l purpose=offensive -l purpose=defensive -l team=sidious"; do
+    run_sloctl get project "$label"
+    verify_get_success "$output" "$want"
+  done
 }
 
 @test "projects, labels filtering with name" {
-	run_sloctl get project -l purpose=defensive hoth-base
-	want=$(read_files "${TEST_INPUTS}/projects.yaml" | yq -r '.[] |= select(.metadata.name == "hoth-base")')
-	verify_get_success "$output" "$want"
+  run_sloctl get project -l purpose=defensive hoth-base
+  want=$(read_files "${TEST_INPUTS}/projects.yaml" | yq -r '.[] |= select(.metadata.name == "hoth-base")')
+  verify_get_success "$output" "$want"
 
-	run_sloctl get project -l purpose=offensive hoth-base
-	assert_success_joined_output
-	assert_output "No resources found."
+  run_sloctl get project -l purpose=offensive hoth-base
+  assert_success_joined_output
+  assert_output "No resources found."
 }
 
 @test "check full alert policy output" {
-	run_sloctl get alertpolicy -p death-star trigger-alert-immediately
-	assert_success_joined_output
-	assert_equal \
-		"$(yq --sort-keys -y -r . <<<"$output")" \
-		"$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/alertpolicy.yaml")"
+  run_sloctl get alertpolicy -p death-star trigger-alert-immediately
+  assert_success_joined_output
+  assert_equal \
+    "$(yq --sort-keys -y -r . <<<"$output")" \
+    "$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/alertpolicy.yaml")"
 }
 
 @test "check full direct output" {
-	run_sloctl get direct -p death-star splunk-direct
-	assert_success_joined_output
-	assert_equal \
-		"$(yq --sort-keys -y -r . <<<"$output")" \
-		"$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/direct.yaml")"
+  run_sloctl get direct -p death-star splunk-direct
+  assert_success_joined_output
+  assert_equal \
+    "$(yq --sort-keys -y -r . <<<"$output")" \
+    "$(yq --sort-keys -y -r . "${TEST_OUTPUTS}/direct.yaml")"
 }
 
 test_get() {
-	local \
-		kind="$1" \
-		input="$3" \
-		output="$4"
-	local aliases
-	IFS=" " read -ra aliases <<<"$2"
-	aliases+=("$kind")
+  local \
+    kind="$1" \
+    input="$3" \
+    output="$4"
+  local aliases
+  IFS=" " read -ra aliases <<<"$2"
+  aliases+=("$kind")
 
-	for alias in "${aliases[@]}"; do
-		# Currently we cannot apply user groups and DataExport has very strict
-		# org limits making it impossible to test with applied objects.
-		if [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "DataExport" ]]; then
-			run_sloctl get "$alias" -A
-			assert_success_joined_output
-			refute_output --partial "Available Commands:"
+  for alias in "${aliases[@]}"; do
+    # Currently we cannot apply user groups and DataExport has very strict
+    # org limits making it impossible to test with applied objects.
+    if [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "DataExport" ]]; then
+      run_sloctl get "$alias"
+      assert_success_joined_output
+      refute_output --partial "Available Commands:"
 
-			continue
-		fi
+      continue
+    fi
 
-		if [[ "$kind" == "Project" ]] || [[ "$kind" == "BudgetAdjustment" ]]; then
-			# shellcheck disable=2046
-			run_sloctl get "$alias" $(yq -r .[].metadata.name "$input")
-			verify_get_success "$output" "$(read_files "$input")"
+    if [[ "$kind" == "Project" ]] || [[ "$kind" == "BudgetAdjustment" ]]; then
+      # shellcheck disable=2046
+      run_sloctl get "$alias" $(yq -r .[].metadata.name "$input")
+      verify_get_success "$output" "$(read_files "$input")"
 
-			continue
-		fi
+      continue
+    fi
 
-		run_sloctl get "$alias" -p "death-star"
-		# Default RoleBinding is created for each project once created so we
-		# need to filter out only the ones we created.
-		if [[ "$kind" == "RoleBinding" ]]; then
-			verify_get_success \
-				"$(yq '[.[] | select(.spec.roleRef == "project-viewer")]' <<<"$output")" \
-				"$(read_files "$input")"
-		else
-			verify_get_success "$output" "$(read_files "$input")"
-		fi
+    run_sloctl get "$alias" -p "death-star"
+    # Default RoleBinding is created for each project once created so we
+    # need to filter out only the ones we created.
+    if [[ "$kind" == "RoleBinding" ]]; then
+      verify_get_success \
+        "$(yq '[.[] | select(.spec.roleRef == "project-viewer")]' <<<"$output")" \
+        "$(read_files "$input")"
+    else
+      verify_get_success "$output" "$(read_files "$input")"
+    fi
 
-		# Make sure the name filtering actually works.
-		first_obj_name="$(yq -r '.[0].metadata.name' "$input")"
-		run_sloctl get "$alias" -p "death-star" "$first_obj_name"
-		verify_get_success "$output" "$(yq -Y '[.[0]]' "$input")"
-	done
+    # Make sure the name filtering actually works.
+    first_obj_name="$(yq -r '.[0].metadata.name' "$input")"
+    run_sloctl get "$alias" -p "death-star" "$first_obj_name"
+    verify_get_success "$output" "$(yq -Y '[.[0]]' "$input")"
+  done
 
-	for alias in "${aliases[@]}"; do
-		if [[ "$kind" == "Project" ]] || [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "BudgetAdjustment" ]]; then
-			run_sloctl get "$alias" "fake-name-123-321"
-			assert_success_joined_output
-			assert_output "No resources found."
+  for alias in "${aliases[@]}"; do
+    if [[ "$kind" == "Project" ]] || [[ "$kind" == "UserGroup" ]] || [[ "$kind" == "BudgetAdjustment" ]]; then
+      run_sloctl get "$alias" "fake-name-123-321"
+      assert_success_joined_output
+      assert_output "No resources found."
 
-			continue
-		fi
+      continue
+    fi
 
-		run_sloctl get "$alias" "fake-name-123-321"
-		assert_success_joined_output
-		assert_output "No resources found in 'default' project."
-		run_sloctl get "$alias" -p "fake-project-123-321"
-		assert_success_joined_output
-		assert_output "No resources found in 'fake-project-123-321' project."
-	done
+    run_sloctl get "$alias" "fake-name-123-321"
+    assert_success_joined_output
+    assert_output "No resources found in 'default' project."
+    run_sloctl get "$alias" -p "fake-project-123-321"
+    assert_success_joined_output
+    assert_output "No resources found in 'fake-project-123-321' project."
+  done
 }
 
 verify_get_success() {
-	local \
-		have="$1" \
-		want="$2"
-	assert_success_joined_output
-	# Since cobra does not return errors on unknown subcommands (https://github.com/spf13/cobra/issues/706)
-	# we need to hack our way around it.
-	refute_output --partial "Available Commands:"
-	# We can't retrieve the same object we applied so we need to compare the minimum.
-	filter='[.[] | {"name": .metadata.name, "project": .metadata.project, "labels": .metadata.labels, "annotations": .metadata.annotations}] | sort_by(.name, .project)'
-	assert_equal \
-		"$(yq --sort-keys -y -r "$filter" <<<"$have")" \
-		"$(yq --sort-keys -y -r "$filter" <<<"$want")"
+  local \
+    have="$1" \
+    want="$2"
+  assert_success_joined_output
+  # Since cobra does not return errors on unknown subcommands (https://github.com/spf13/cobra/issues/706)
+  # we need to hack our way around it.
+  refute_output --partial "Available Commands:"
+  # We can't retrieve the same object we applied so we need to compare the minimum.
+  filter='[.[] | {"name": .metadata.name, "project": .metadata.project, "labels": .metadata.labels, "annotations": .metadata.annotations}] | sort_by(.name, .project)'
+  assert_equal \
+    "$(yq --sort-keys -y -r "$filter" <<<"$have")" \
+    "$(yq --sort-keys -y -r "$filter" <<<"$want")"
 }

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -91,7 +91,7 @@ _assert_objects_existence() {
     name=$(yq -r .metadata.name <<<"$object")
     kind=$(yq -r .kind <<<"$object")
     args=("get" "${kind,,}" "$name") # Converts kind to lowercase.
-    if [[ "$kind" != "Project" ]] && [[ "$kind" != "RoleBinding" ]]; then
+    if [[ "$kind" != "Project" ]] && [[ "$kind" != "RoleBinding" ]] && [[ "$kind" != "BudgetAdjustment" ]]; then
       project=$(yq -r .metadata.project <<<"$object")
       args+=(-p "$project")
     fi


### PR DESCRIPTION
## Motivation

For a long time `sloctl` had `-p` and `-A` flags available in the global scope, even if specific sub-commands were not using it.
Similarly, `-l` flag for `get <object>` command was available even for objects which do not support labels filtering.
This PR finally fixes these issues and sets the aforementioned flags contextually, only when it makes sense.

## Testing

- Ensure all the `-p` flag usage works for project scoped objects on `delete` (by name) and `get` commands.
- Ensure `-A` flag is only visible/usable for `get` command for project scoped objects, and that it works.
- Ensure `-l` flag for labels filtering is only visible for objects supporting labels, and that it works.

Successful run: https://github.com/nobl9/sloctl/actions/runs/10200396849/job/28219757765

## Breaking Changes

`get` command exposes `-l` flag for objects which support labels filtering, in addition `-p` and `-A` flags are now only available for Project scoped objects.
`delete <name>` command no longer supports `-A` flag and supports `-p` flag only for Project scoped objects.
`get alert` command now prints _No resources found._ notice, just like the rest of `get <object>` commands.
