### PR TITLE
chore: Update goreleaser to v2 and action to v6

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -22,7 +22,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - name: Release Binaries
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean --skip=homebrew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: No-op approval
         run: echo "This is a no-op step, QA needs to approve it and may perform testing beforehand"
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     needs: [test, qa-approval]
     steps:
@@ -59,7 +59,7 @@ jobs:
             type=sha
             type=semver,pattern={{version}}
       - name: Release Binaries
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean
@@ -77,7 +77,7 @@ jobs:
           build-args: LDFLAGS=-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=${{ github.ref_name }}
   docker-test:
     uses: ./.github/workflows/e2e-tests.yml
-    needs: [goreleaser]
+    needs: [release]
     strategy:
       matrix:
         image: [nobl9/sloctl, quay.io/nobl9/sloctl]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: sloctl
 
 builds:


### PR DESCRIPTION
Followed this tutorial to make sure the upgrade is successful: https://goreleaser.com/blog/goreleaser-v2