### PR TITLE
fix: Bring back get alerts project flags

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -67,6 +67,9 @@ var projectFlagSupportingKinds = map[manifest.Kind]struct{}{
 	manifest.KindDataExport:   {},
 	manifest.KindRoleBinding:  {},
 	manifest.KindAnnotation:   {},
+	// While Alert itself is not Project scoped per-se,
+	// it does support Project filtering.
+	manifest.KindAlert: {},
 }
 
 func objectKindSupportsProjectFlag(kind manifest.Kind) bool {

--- a/internal/get.go
+++ b/internal/get.go
@@ -249,7 +249,7 @@ func (g *GetCmd) newGetAlertCommand(cmd *cobra.Command) *cobra.Command {
 			return err
 		}
 		if len(objects) == 0 {
-			fmt.Printf("No resources found.\n")
+			fmt.Printf("No resources found in '%s' project.\n", g.client.Config.Project)
 			return nil
 		}
 		if err = g.printObjects(objects); err != nil {


### PR DESCRIPTION
## Motivation

Alerts, while not directly Project scoped, support Project filtering.
With the changes introduced in https://github.com/nobl9/sloctl/pull/177, the flag was removed.
This PR brings it back.

## Testing

Build sloctl with `make build` locally and run `sloctl get alert -A` and `sloctl get alert -p <project_name>`.

## Release Notes

`sloctl get alert` once again supports both `-p` and `-A` flags for Project filtering.
These flags were removed as a regression in v0.4.0.

