### PR TITLE
fix: Add project flag back again for sloctl replay

### DIFF
--- a/internal/apply.go
+++ b/internal/apply.go
@@ -52,7 +52,8 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 	registerFileFlag(cmd, true, &apply.definitionPaths)
 	registerDryRunFlag(cmd, &apply.dryRun)
 	registerAutoConfirmationFlag(cmd, &apply.autoConfirm)
-	registerProjectFlag(cmd, &apply.project)
+	cmd.Flags().StringVarP(&apply.project, "project", "p", "",
+		`Specifies a default Project to assign to the resources if no Project was defined in the object's definition.`)
 
 	const (
 		replayFlagName     = "replay"

--- a/internal/apply.go
+++ b/internal/apply.go
@@ -53,7 +53,7 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 	registerDryRunFlag(cmd, &apply.dryRun)
 	registerAutoConfirmationFlag(cmd, &apply.autoConfirm)
 	cmd.Flags().StringVarP(&apply.project, "project", "p", "",
-		`Assigns the provided Project to the resources if no Project was defined in the object's definition.`)
+		`Assigns the provided Project to the resources if no Project is defined in the object's definition.`)
 
 	const (
 		replayFlagName     = "replay"

--- a/internal/apply.go
+++ b/internal/apply.go
@@ -53,7 +53,7 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 	registerDryRunFlag(cmd, &apply.dryRun)
 	registerAutoConfirmationFlag(cmd, &apply.autoConfirm)
 	cmd.Flags().StringVarP(&apply.project, "project", "p", "",
-		`Assigns the provied Project to the resources if no Project was defined in the object's definition.`)
+		`Assigns the provided Project to the resources if no Project was defined in the object's definition.`)
 
 	const (
 		replayFlagName     = "replay"

--- a/internal/apply.go
+++ b/internal/apply.go
@@ -53,7 +53,7 @@ func (r *RootCmd) NewApplyCmd() *cobra.Command {
 	registerDryRunFlag(cmd, &apply.dryRun)
 	registerAutoConfirmationFlag(cmd, &apply.autoConfirm)
 	cmd.Flags().StringVarP(&apply.project, "project", "p", "",
-		`Specifies a default Project to assign to the resources if no Project was defined in the object's definition.`)
+		`Assigns the provied Project to the resources if no Project was defined in the object's definition.`)
 
 	const (
 		replayFlagName     = "replay"

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -131,7 +131,7 @@ func newSubcommand(
 	}
 	if objectKindSupportsProjectFlag(kind) {
 		sc.Flags().StringVarP(&deleteCmd.project, "project", "p", "",
-			`Specifies which Project to delete the resources from. If not provided, the default Project will be used.`)
+			`Specifies the Project from which to delete the resources. If not provided, the default Project will be used.`)
 	}
 	registerDryRunFlag(sc, &deleteCmd.dryRun)
 	return sc

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -52,7 +52,7 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	registerDryRunFlag(cmd, &deleteCmd.dryRun)
 	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
 	cmd.Flags().StringVarP(&deleteCmd.project, "project", "p", "",
-		`Assigns the provided Project to the resources if no Project was defined in the object's definition.`)
+		`Assigns the provided Project to the resources if no Project is defined in the object's definition.`)
 
 	// register all subcommands for delete
 	for _, def := range []struct {

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -51,7 +51,8 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	registerFileFlag(cmd, false, &deleteCmd.definitionPaths)
 	registerDryRunFlag(cmd, &deleteCmd.dryRun)
 	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
-	registerProjectFlag(cmd, &deleteCmd.project)
+	cmd.Flags().StringVarP(&deleteCmd.project, "project", "p", "",
+		`Specifies a default Project to assign to the resources if no Project was defined in the object's definition.`)
 
 	// register all subcommands for delete
 	for _, def := range []struct {
@@ -129,7 +130,8 @@ func newSubcommand(
 		},
 	}
 	if objectKindSupportsProjectFlag(kind) {
-		registerProjectFlag(sc, &deleteCmd.project)
+		sc.Flags().StringVarP(&deleteCmd.project, "project", "p", "",
+			`Specifies which Project to delete the resources from. If not provided, the default Project will be used.`)
 	}
 	registerDryRunFlag(sc, &deleteCmd.dryRun)
 	return sc

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -52,7 +52,7 @@ func (r *RootCmd) NewDeleteCmd() *cobra.Command {
 	registerDryRunFlag(cmd, &deleteCmd.dryRun)
 	registerAutoConfirmationFlag(cmd, &deleteCmd.autoConfirm)
 	cmd.Flags().StringVarP(&deleteCmd.project, "project", "p", "",
-		`Specifies a default Project to assign to the resources if no Project was defined in the object's definition.`)
+		`Assigns the provided Project to the resources if no Project was defined in the object's definition.`)
 
 	// register all subcommands for delete
 	for _, def := range []struct {

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -77,16 +77,6 @@ func objectKindSupportsProjectFlag(kind manifest.Kind) bool {
 	return ok
 }
 
-func registerProjectFlag(cmd *cobra.Command, storeIn *string) {
-	cmd.Flags().StringVarP(storeIn, "project", "p", "",
-		`List the requested object(s) which belong to the specified Project (name).`)
-}
-
-func registerAllProjectsFlag(cmd *cobra.Command, storeIn *bool) {
-	cmd.Flags().BoolVarP(storeIn, "all-projects", "A", false,
-		`List the requested object(s) across all projects.`)
-}
-
 var labelSupportingKinds = map[manifest.Kind]struct{}{
 	manifest.KindProject:     {},
 	manifest.KindService:     {},

--- a/internal/get.go
+++ b/internal/get.go
@@ -98,9 +98,9 @@ To get more details in output use one of the available flags.`,
 			subCmd.Extender(sc)
 		}
 		if objectKindSupportsProjectFlag(subCmd.Kind) {
-			cmd.Flags().StringVarP(&get.project, "project", "p", "",
+			sc.Flags().StringVarP(&get.project, "project", "p", "",
 				`List the requested object(s) which belong to the specified Project (name).`)
-			cmd.Flags().BoolVarP(&get.allProjects, "all-projects", "A", false,
+			sc.Flags().BoolVarP(&get.allProjects, "all-projects", "A", false,
 				`List the requested object(s) across all projects.`)
 		}
 		if objectKindSupportsLabelsFlag(subCmd.Kind) {

--- a/internal/get.go
+++ b/internal/get.go
@@ -98,8 +98,10 @@ To get more details in output use one of the available flags.`,
 			subCmd.Extender(sc)
 		}
 		if objectKindSupportsProjectFlag(subCmd.Kind) {
-			registerProjectFlag(sc, &get.project)
-			registerAllProjectsFlag(sc, &get.allProjects)
+			cmd.Flags().StringVarP(&get.project, "project", "p", "",
+				`List the requested object(s) which belong to the specified Project (name).`)
+			cmd.Flags().BoolVarP(&get.allProjects, "all-projects", "A", false,
+				`List the requested object(s) across all projects.`)
 		}
 		if objectKindSupportsLabelsFlag(subCmd.Kind) {
 			registerLabelsFlag(sc, &get.labels)

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -67,7 +67,8 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 	}
 
 	registerFileFlag(cmd, false, &replay.configPaths)
-	registerProjectFlag(cmd, &replay.project)
+	cmd.Flags().StringVarP(&replay.project, "project", "p", "",
+		`Specifies the Project for the SLOs you want to run Replay for.`)
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
 	return cmd

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -33,6 +33,7 @@ type ReplayCmd struct {
 	from        TimeValue
 	configPaths []string
 	sloName     string
+	project     string
 }
 
 //go:embed replay_example.sh
@@ -54,13 +55,19 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 			"Importing data takes time: Replay for a single SLO may take several minutes up to an hour. " +
 			"During that time, the command keeps on running, periodically checking the status of Replay. " +
 			"If you cancel the program execution at any time, the current Replay in progress will not be revoked.",
-		Example:          replayExample,
-		Args:             replay.arguments,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) { replay.client = r.GetClient() },
-		RunE:             func(cmd *cobra.Command, args []string) error { return replay.Run(cmd) },
+		Example: replayExample,
+		Args:    replay.arguments,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			replay.client = r.GetClient()
+			if replay.project != "" {
+				replay.client.Config.Project = replay.project
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error { return replay.Run(cmd) },
 	}
 
 	registerFileFlag(cmd, false, &replay.configPaths)
+	registerProjectFlag(cmd, &replay.project)
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
 	return cmd

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -68,7 +68,7 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 
 	registerFileFlag(cmd, false, &replay.configPaths)
 	cmd.Flags().StringVarP(&replay.project, "project", "p", "",
-		`Specifies the Project for the SLOs you want to run Replay for.`)
+		`Specifies the Project for the SLOs you want to Replay.`)
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
 	return cmd


### PR DESCRIPTION
https://github.com/nobl9/sloctl/pull/177 removed default project flags, unfortunately we missed the `sloctl replay` command which also relied on them.

This PR brings the `-p` flag back for `sloctl replay` command.