### PR TITLE
fix: Correct sloctl replay help

### DIFF
--- a/internal/replay_example.sh
+++ b/internal/replay_example.sh
@@ -10,7 +10,7 @@ sloctl replay <./replay.yaml
 # If the project is not set, it is inferred from Nobl9 config.toml for the current context.
 # If 'from' is not provided in the config file, you must specify it with '--from' flag.
 # Setting 'project' or 'from' via flags does not take precedence over the values set in config.
-cat <<EOF | sloctl replay --from=2023-03-02T15:00:00Z
+cat <<EOF > ./replay.yaml
 - slo: prometheus-latency
   from: 2023-03-02T16:00:00Z
 - slo: datadog-latency
@@ -19,9 +19,11 @@ cat <<EOF | sloctl replay --from=2023-03-02T15:00:00Z
   project: default
   from: 2023-03-02T16:00:00Z
 EOF
+sloctl -f ./replay.yaml replay --from=2023-03-02T15:00:00Z
 
 # Minimal config with project and from set via flags.
-cat <<EOF | sloctl replay -p my-project --from 2023-03-02T15:00:00Z
+cat <<EOF > ./replay.yaml
 - slo: prometheus-latency
 - slo: datadog-latency
 EOF
+sloctl replay -f ./replay.yaml -p my-project --from 2023-03-02T15:00:00Z

--- a/internal/root.go
+++ b/internal/root.go
@@ -40,7 +40,7 @@ For every command more detailed help is available.`,
 	}
 
 	root := RootCmd{}
-	rootCmd.Flags().BoolP("help", "h", false, fmt.Sprintf("Help for %s.", rootCmd.Name()))
+	rootCmd.PersistentFlags().BoolP("help", "h", false, fmt.Sprintf("Help for %s.", rootCmd.Name()))
 	rootCmd.PersistentFlags().StringVar(&root.Flags.ConfigFile, "config", "", "Config file path.")
 	rootCmd.PersistentFlags().StringVarP(&root.Flags.Context, "context", "c", "",
 		`Overrides the default context for the duration of the selected command.`)


### PR DESCRIPTION
## Summary

Correct invalid docs for `sloctl replay`.
Make `help` flag override persistent.

## Release Notes

`sloctl replay` help message examples were presenting unsupported usage of stdin for passing file config.
The only supported way of providing the config is with `-f` flag.

