### PR TITLE
fix: Fix delete report test

### DIFF
--- a/test/inputs/delete-by-name/report.yaml
+++ b/test/inputs/delete-by-name/report.yaml
@@ -23,3 +23,7 @@ spec:
         labels:
           planet:
             - alderaan
+    thresholds:
+      redLte: 0.8
+      greenGt: 0.95
+      showNoData: false


### PR DESCRIPTION
## Summary

Correct failing delete report test (new required `thresholds` field was missing).