### PR TITLE
chore: Update gofmt usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ format: format/go format/cspell
 format/go:
 	echo "Formatting Go files..."
 	$(call _ensure_installed,binary,goimports)
-	go fmt ./...
+	gofmt -w -l -s .
 	$(BIN_DIR)/goimports -local=github.com/nobl9/sloctl -w .
 
 ## Format cspell config file.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -32,6 +32,7 @@ words:
   - dynatrace
   - endef
   - gobin
+  - gofmt
   - goimports
   - golangci
   - gosec


### PR DESCRIPTION
By default `go fmt` calls `gofmt -w -l`, with the recent golangci linter changes it seems it's not enough, and rightfully so.
It now requires the files to be formatted with `-s` flag which simplifies code, for instance removing unnecessary type literals in slice declarations. 

Example linter fail due to unsimplified code: https://github.com/nobl9/nobl9-go/actions/runs/11123928510/job/30908411560