### PR TITLE
feat: PC-13613 remove replay from queue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,7 +67,7 @@ linters:
     - dogsled
     - errcheck
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - gochecknoinits
     - gocognit
     - gocritic

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nobl9/sloctl
 
-go 1.22
+go 1.23
 
 require (
 	github.com/go-playground/validator/v10 v10.22.1

--- a/internal/get.go
+++ b/internal/get.go
@@ -327,7 +327,6 @@ func (g *GetCmd) getAgentsWithSecrets(ctx context.Context, objects []manifest.Ob
 	var mu sync.Mutex
 	eg, ctx := errgroup.WithContext(ctx)
 	for i := range objects {
-		i := i
 		eg.Go(func() error {
 			agent, ok := objects[i].(v1alpha.GenericObject)
 			if !ok {

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -71,6 +71,8 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 		`Specifies the Project for the SLOs you want to Replay.`)
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
+	cmd.AddCommand(replay.AddDeleteCommand())
+
 	return cmd
 }
 
@@ -114,6 +116,19 @@ func (r *ReplayCmd) RunReplays(cmd *cobra.Command, replays []ReplayConfig) (fail
 		r.printSummary(cmd, replays, failedIndexes)
 	}
 	return len(failedIndexes), nil
+}
+
+// AddDeleteCommand returns cobra command delete, allows to delete a replay from a queue.
+func (r *ReplayCmd) AddDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a replay from a queue",
+		Long:  "Delete a replay from a queue.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Deleting replays from a queue\n")
+			return nil
+		},
+	}
 }
 
 type ReplayConfig struct {
@@ -427,6 +442,7 @@ func (r *ReplayCmd) getReplayStatus(
 
 const (
 	endpointReplayPost            = "/timetravel"
+	endpointReplayDelete          = "/timetravel"
 	endpointReplayGetStatus       = "/timetravel/%s"
 	endpointReplayGetAvailability = "/internal/timemachine/availability"
 	endpointGetSLO                = "/get/slo"

--- a/internal/replay_delete.go
+++ b/internal/replay_delete.go
@@ -1,0 +1,54 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// AddDeleteCommand returns cobra command delete, allows to delete a replay from a queue.
+func (r *ReplayCmd) AddDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <slo-name>",
+		Short: "Delete a replay from a queue",
+		Long:  "Delete a replay from a queue.",
+		Args:  r.deleteArguments,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if r.all {
+				return r.deleteAllReplays()
+			} else {
+				return r.deleteReplaysForSLO(r.sloName, r.project)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&r.project, "project", "p", "",
+		`Specifies the Project of the SLO you want to remove Replays from queue for.`)
+	cmd.Flags().BoolVar(&r.all, "all", false, "Delete ALL replays in queue.")
+
+	return cmd
+}
+
+func (r *ReplayCmd) deleteArguments(cmd *cobra.Command, args []string) error {
+	if !r.all && len(args) == 0 {
+		_ = cmd.Usage()
+		return errReplayDeleteInvalidOptions
+	}
+	if len(args) > 1 {
+		return errReplayTooManyArgs
+	}
+	if len(args) == 1 {
+		r.sloName = args[0]
+	}
+	return nil
+}
+
+func (r *ReplayCmd) deleteAllReplays() error {
+	fmt.Printf("Deleting all replays from queue\n")
+	return nil
+}
+
+func (r *ReplayCmd) deleteReplaysForSLO(sloName, project string) error {
+	fmt.Printf("Deleting replays from a queue for SLO %s in project %s\n", sloName, project)
+	return nil
+}

--- a/internal/replay_errors.go
+++ b/internal/replay_errors.go
@@ -1,0 +1,16 @@
+package internal
+
+import "github.com/pkg/errors"
+
+var (
+	errReplayInvalidOptions = errors.New("you must either run 'sloctl replay' for a single SLO," +
+		" providing its name as an argument, or provide configuration file using '-f' flag, but not both")
+	errReplayDeleteInvalidOptions = errors.New("you must either run 'sloctl replay delete' for a single " +
+		"SLO, providing its name as an argument, or use the '--all' flag to delete all queued replays, but not both")
+	errReplayTooManyArgs = errors.New("'replay' command accepts a single SLO name," +
+		" If you want to run it for multiple SLOs provide a configuration file instead using '-f' flag")
+	errReplayMissingFromArg = errors.Errorf("when running 'sloctl replay' for a single SLO,"+
+		" you must provide Replay window start time (%s layout) with '--from' flag", timeLayoutString)
+	errProjectWildcardIsNotAllowed = errors.New(
+		"wildcard Project is not allowed, you must provide specific Project name(s)")
+)


### PR DESCRIPTION
## Motivation

Ability to control the upcoming feature through sloctl.

## Summary

- Upgraded to go 1.23
- Updated linter rules
- Added sloctl replay delete --all and sloctl replay delete sloName -p projectName

## Testing

- Run replay (normal, without queue)
- Get agents (change in get agents command)
- Add replays to queue, then try deleting them using sloctl (both all and for specific SLO)


Release notes intentionally left empty, to be filled in when the feature is released.
## Release Notes


