### PR TITLE
feat: List the queued replays [PC-13341]

### DIFF
--- a/internal/replay.go
+++ b/internal/replay.go
@@ -73,6 +73,7 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 	cmd.Flags().Var(&replay.from, "from", "Sets the start of Replay time window.")
 
 	cmd.AddCommand(replay.AddDeleteCommand())
+	cmd.AddCommand(replay.AddListCommand())
 
 	return cmd
 }
@@ -425,6 +426,7 @@ func (r *ReplayCmd) getReplayStatus(
 const (
 	endpointReplayPost            = "/timetravel"
 	endpointReplayDelete          = "/timetravel"
+	endpointReplayList            = "/timetravel/list"
 	endpointReplayGetStatus       = "/timetravel/%s"
 	endpointReplayGetAvailability = "/internal/timemachine/availability"
 	endpointGetSLO                = "/get/slo"

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -7,8 +7,9 @@ import (
 	"os"
 
 	"github.com/mitchellh/colorstring"
-	"github.com/nobl9/sloctl/internal/printer"
 	"github.com/spf13/cobra"
+
+	"github.com/nobl9/sloctl/internal/printer"
 )
 
 // AddListCommand returns cobra command list, which allows to list all queued Replays.
@@ -23,7 +24,7 @@ func (r *ReplayCmd) AddListCommand() *cobra.Command {
 	return cmd
 }
 
-type ReplayList struct {
+type ReplayQueueItem struct {
 	Slo            string `json:"slo,omitempty"`
 	Project        string `json:"project"`
 	ElapsedTime    string `json:"elapsedTime,omitempty"`
@@ -47,16 +48,16 @@ func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
 		return err
 	}
 
-	var replayList []ReplayList
-	if err := json.Unmarshal(response, &replayList); err != nil {
+	var replayQueueList []ReplayQueueItem
+	if err := json.Unmarshal(response, &replayQueueList); err != nil {
 		fmt.Printf("err: %v\n", err)
 	}
 
-	p, err := printer.New(os.Stdout, "yaml", "|", "-")
+	p, err := printer.New(os.Stdout, "yaml", "", "")
 	if err != nil {
 		return err
 	}
-	if err = p.Print(replayList); err != nil {
+	if err = p.Print(replayQueueList); err != nil {
 		return err
 	}
 	return nil

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -34,7 +34,7 @@ type ReplayQueueItem struct {
 }
 
 func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
-	cmd.Println(colorstring.Color("[yellow]Listing all queued Replays[reset]"))
+	cmd.Println(colorstring.Color("[yellow]Listing all Replays[reset]"))
 
 	response, err := r.doRequest(
 		cmd.Context(),

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -3,11 +3,12 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/mitchellh/colorstring"
 	"github.com/nobl9/sloctl/internal/printer"
 	"github.com/spf13/cobra"
-	"net/http"
-	"os"
 )
 
 // AddListCommand returns cobra command list, which allows to list all queued Replays.

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/mitchellh/colorstring"
+	"github.com/nobl9/sloctl/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// AddListCommand returns cobra command list, which allows to list all queued Replays.
+func (r *ReplayCmd) AddListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List queued Replays",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.listAllReplays(cmd)
+		},
+	}
+	return cmd
+}
+
+type ReplayList struct {
+	Slo            string `json:"slo,omitempty"`
+	Project        string `json:"project"`
+	ElapsedTime    string `json:"elapsedTime,omitempty"`
+	RetrievedScope string `json:"retrievedScope,omitempty"`
+	RetrievedFrom  string `json:"retrievedFrom,omitempty"`
+	Status         string `json:"status"`
+}
+
+func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
+	cmd.Println(colorstring.Color("[yellow]Listing all queued Replays[reset]"))
+
+	response, err := r.doRequest(
+		cmd.Context(),
+		http.MethodGet,
+		endpointReplayList,
+		"",
+		nil,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	var replayList []ReplayList
+	if err := json.Unmarshal(response, &replayList); err != nil {
+		fmt.Printf("err: %v\n", err)
+	}
+
+	p, err := printer.New(os.Stdout, "yaml", "|", "-")
+	if err != nil {
+		return err
+	}
+	if err = p.Print(replayList); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -16,7 +16,7 @@ import (
 func (r *ReplayCmd) AddListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List queued Replays",
+		Short: "List all Replays",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.listAllReplays(cmd)
 		},

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -3,13 +3,11 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mitchellh/colorstring"
+	"github.com/nobl9/sloctl/internal/printer"
+	"github.com/spf13/cobra"
 	"net/http"
 	"os"
-
-	"github.com/mitchellh/colorstring"
-	"github.com/spf13/cobra"
-
-	"github.com/nobl9/sloctl/internal/printer"
 )
 
 // AddListCommand returns cobra command list, which allows to list all queued Replays.
@@ -53,12 +51,17 @@ func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
 		fmt.Printf("err: %v\n", err)
 	}
 
-	p, err := printer.New(os.Stdout, "yaml", "", "")
-	if err != nil {
-		return err
-	}
-	if err = p.Print(replayQueueList); err != nil {
-		return err
+	if len(replayQueueList) == 0 {
+		cmd.Println(colorstring.Color("[light_gray]No Replays found[reset]"))
+		return nil
+	} else {
+		p, err := printer.New(os.Stdout, "yaml", "", "")
+		if err != nil {
+			return err
+		}
+		if err = p.Print(replayQueueList); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -54,7 +54,7 @@ func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
 	}
 
 	if len(replayQueueList) == 0 {
-		cmd.Println(colorstring.Color("[light_gray]No Replays found[reset]"))
+		cmd.Println(colorstring.Color("[light_gray]Replay not found[reset]"))
 		return nil
 	} else {
 		p, err := printer.New(os.Stdout, "yaml", "", "")

--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -7,8 +7,9 @@ import (
 	"os"
 
 	"github.com/mitchellh/colorstring"
-	"github.com/nobl9/sloctl/internal/printer"
 	"github.com/spf13/cobra"
+
+	"github.com/nobl9/sloctl/internal/printer"
 )
 
 // AddListCommand returns cobra command list, which allows to list all queued Replays.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "cspell": "8.15.1",
     "markdownlint-cli": "0.41.0",
-    "yaml": "2.5.1"
+    "yaml": "2.6.0"
   },
   "scripts": {
     "check-trailing-whitespaces": "node ./scripts/check-trailing-whitespaces.js",


### PR DESCRIPTION
## Motivation

Ability to list all queued replays through sloctl.

## Summary

Added new command `sloctl replay list`

## Related changes

https://github.com/nobl9/n9/pull/15630


## Release Notes

