### PR TITLE
chore: Update messaging around `replay` command [PC-14729]

### DIFF
--- a/internal/replay.go
+++ b/internal/replay.go
@@ -94,7 +94,7 @@ func (r *ReplayCmd) RunReplays(cmd *cobra.Command, replays []ReplayConfig) (fail
 	if arePlaylistEnabled {
 		cmd.Println(colorstring.Color("[yellow]- Your organization has access to Replay queues!"))
 		cmd.Println(colorstring.Color("[yellow]- To learn more about Replay queues, follow this link: " +
-			"https://docs.nobl9.com/replay-canary/ [reset]"))
+			"https://docs.nobl9.com/replay [reset]"))
 	}
 
 	failedIndexes := make([]int, 0)

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -94,7 +94,7 @@ func (r *ReplayCmd) RunReplays(cmd *cobra.Command, replays []ReplayConfig) (fail
 	if arePlaylistEnabled {
 		cmd.Println(colorstring.Color("[yellow]- Your organization has access to Replay queues!"))
 		cmd.Println(colorstring.Color("[yellow]- To learn more about Replay queues, follow this link: " +
-			"https://docs.nobl9.com/replay [reset]"))
+			"https://docs.nobl9.com/replay/replay-sloctl [reset]"))
 	}
 
 	failedIndexes := make([]int, 0)

--- a/internal/replay.go
+++ b/internal/replay.go
@@ -49,8 +49,7 @@ func (r *RootCmd) NewReplayCmd() *cobra.Command {
 		Long: "`sloctl replay` creates Replays to retrieve historical data for SLOs. " +
 			"Use it to replay SLOs one-by-one or in bulk. Historical data retrieval is time-consuming: " +
 			"replaying a single SLO can take up to an hour. Considering the number of ongoing Replays is limited, " +
-			"`sloctl` queues Replays if the limit is exceeded. Replay queues is an experimental feature, currently " +
-			"unavailable to all organizations. We're working on improving and expanding its availability.",
+			"`sloctl` queues Replays if the limit is exceeded.",
 		Example: replayExample,
 		Args:    replay.arguments,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
## Motivation

Adjusting the messaging for the `replay` command, including navigating to the proper docs location about the replay feature. 

## Summary

Only messages for `replay` command were changed.

## Testing

Try to queue the replay using `sloctl` and observe changed messaging for a long description of `replay` command.

## Release Notes

Introducing Replay queues - the ability to queue the replay to be invoked automatically.
