### PR TITLE
feat: Extend release targets and add install.bash script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,14 +16,15 @@ builds:
     - darwin
   goarch:
     - amd64
+    - arm64
   binary: '{{ .ProjectName }}'
 
 archives:
 - format: binary
-  name_template: '{{ .ProjectName }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ .Version }}'
+  name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
 
 checksum:
-  name_template: '{{ .ProjectName }}-{{ .Version }}-SHA256SUMS'
+  name_template: '{{ .ProjectName }}-{{ .Version }}.sha256'
   algorithm: sha256
 
 release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,8 @@ builds:
   binary: '{{ .ProjectName }}'
 
 archives:
-- format: binary
+- formats:
+    - binary
   name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}'
 
 checksum:

--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ chmod 700 install.bash
 ./install.bash --help
 ```
 
-*NOTE:* If you install sloctl outside of your PATH you must also
-change its permissions for the binary to be executable!
-
-```bash
-chmod +x <PATH_TO_SLOCTL>
-```
+> [!NOTE]
+> If you install sloctl outside of your PATH you must also
+> change its permissions for the binary to be executable!
+>
+> ```bash
+> chmod +x <PATH_TO_SLOCTL>
+> ```
 
 ### Prebuilt Binaries
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,6 @@ chmod 700 install.bash
 ./install.bash --help
 ```
 
-> [!NOTE]
-> If you install sloctl outside of your PATH you must also
-> change its permissions for the binary to be executable!
->
-> ```bash
-> chmod +x <PATH_TO_SLOCTL>
-> ```
-
 ### Prebuilt Binaries
 
 The binaries are available at

--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ If you want to learn how to fully tame the sloctl's potential, see
 
 ## Install
 
+### Script
+
+The script requires bash and a minimal set of GNU utilities.
+On Windows it will work with either MinGW or Cygwin.
+You can either pipe it directly into bash or download the file and run it manually.
+
+```bash
+# Using curl:
+curl -fsSL https://raw.githubusercontent.com/nobl9/sloctl/main/install.bash | bash
+
+# On systems where curl is not available:
+wget -O - -q https://raw.githubusercontent.com/nobl9/sloctl/main/install.bash | bash
+
+# If you prefer to first download the script, inspect it and then run it:
+curl -fsSL -o install.bash https://raw.githubusercontent.com/nobl9/sloctl/main/install.bash
+# Or with wget:
+wget -O install.bash -q https://raw.githubusercontent.com/nobl9/sloctl/main/install.bash
+# Once downloaded, set execution permissions:
+chmod 700 install.bash
+# The script is well documented and comes with additional options.
+# You can display the help message by running:
+./install.bash --help
+```
+
 ### Prebuilt Binaries
 
 The binaries are available at

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ chmod 700 install.bash
 ./install.bash --help
 ```
 
+*NOTE:* If you install sloctl outside of your PATH you must also
+change its permissions for the binary to be executable!
+
+```bash
+chmod +x <PATH_TO_SLOCTL>
+```
+
 ### Prebuilt Binaries
 
 The binaries are available at

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -28,6 +28,7 @@ ignorePaths:
   - "**/test_data/**"
   - dist/**
 words:
+  - armv
   - distroless
   - dynatrace
   - endef

--- a/install.bash
+++ b/install.bash
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-# The install script is based off of the Apache 2.0 licensed script from Helm,
+# The install script is based on the Apache 2.0 licensed script from Helm,
 # the Kubernetes resource manager: https://github.com/helm/helm.
+# Original script from Helm: 
+#   https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 
 PROGRAM_NAME="sloctl"
 GITHUB_REPOSITORY="nobl9/$PROGRAM_NAME"
@@ -277,7 +279,7 @@ while (("$#")); do
   --dir | -d)
     shift
     PROGRAM_INSTALL_DIR="$1"
-    shift
+    shift # Shift again to remove the directory argument.
     ;;
   '--no-sudo')
     shift

--- a/install.bash
+++ b/install.bash
@@ -167,7 +167,8 @@ downloadFile() {
 installFile() {
   local destination="${PROGRAM_INSTALL_DIR}/${PROGRAM_NAME}${PROGRAM_EXTENSION}"
   echo "Preparing to install ${PROGRAM_NAME} into ${PROGRAM_INSTALL_DIR}"
-  runAsRoot cp "$PROGRAM_TMP_BIN" "$destination" 
+  runAsRoot cp "$PROGRAM_TMP_BIN" "$destination"
+  runAsRoot chmod +x "$destination"
   echo "${PROGRAM_NAME} installed into ${destination}"
 }
 
@@ -284,7 +285,7 @@ while (("$#")); do
     ;;
   --dir | -d)
     shift
-    PROGRAM_INSTALL_DIR="$1"
+    PROGRAM_INSTALL_DIR="${1%/}" # Remove extra slash from the path if present.
     shift # Shift again to remove the directory argument.
     ;;
   '--no-sudo')

--- a/install.bash
+++ b/install.bash
@@ -14,6 +14,7 @@ USE_SUDO="true"
 DEBUG="false"
 VERIFY_CHECKSUM="true"
 PROGRAM_INSTALL_DIR="/usr/local/bin"
+PROGRAM_EXTENSION=""
 
 HAS_CURL="$(type "curl" &>/dev/null && echo true || echo false)"
 HAS_WGET="$(type "wget" &>/dev/null && echo true || echo false)"
@@ -49,6 +50,10 @@ initOS() {
   # Minimalist GNU for Windows
   mingw* | cygwin*) OS='windows' ;;
   esac
+
+  if [[ "$OS" == "windows" ]]; then
+    PROGRAM_EXTENSION=".exe"
+  fi
 }
 
 # runs the given command as root (detects if we are root already)
@@ -133,14 +138,14 @@ checkInstalledVersion() {
 downloadFile() {
   VERSION="${TAG#v}"
 
-  PROGRAM_DIST="${PROGRAM_NAME}-${VERSION}-${OS}-${ARCH}"
+  PROGRAM_DIST="${PROGRAM_NAME}-${VERSION}-${OS}-${ARCH}${PROGRAM_EXTENSION}"
   DOWNLOAD_BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/$TAG"
 
   DOWNLOAD_URL="${DOWNLOAD_BASE_URL}/${PROGRAM_DIST}"
   CHECKSUM_URL="${DOWNLOAD_BASE_URL}/${PROGRAM_NAME}-${VERSION}.sha256"
 
   PROGRAM_TMP_ROOT="$(mktemp -dt "${PROGRAM_NAME}-installer-XXXXXX")"
-  PROGRAM_TMP_BIN="${PROGRAM_TMP_ROOT}/${PROGRAM_NAME}"
+  PROGRAM_TMP_BIN="${PROGRAM_TMP_ROOT}/${PROGRAM_NAME}${PROGRAM_EXTENSION}"
   PROGRAM_SUM_FILE="${PROGRAM_TMP_ROOT}/${PROGRAM_NAME}-${VERSION}.sha256"
 
   echo "Downloading ${DOWNLOAD_URL}"
@@ -160,9 +165,10 @@ downloadFile() {
 
 # installFile installs the program binary.
 installFile() {
+  local destination="${PROGRAM_INSTALL_DIR}/${PROGRAM_NAME}${PROGRAM_EXTENSION}"
   echo "Preparing to install ${PROGRAM_NAME} into ${PROGRAM_INSTALL_DIR}"
-  runAsRoot cp "$PROGRAM_TMP_BIN" "${PROGRAM_INSTALL_DIR}/${PROGRAM_NAME}"
-  echo "${PROGRAM_NAME} installed into ${PROGRAM_INSTALL_DIR}/${PROGRAM_NAME}"
+  runAsRoot cp "$PROGRAM_TMP_BIN" "$destination" 
+  echo "${PROGRAM_NAME} installed into ${destination}"
 }
 
 # verifyChecksum verifies the SHA256 checksum of the binary package.

--- a/install.bash
+++ b/install.bash
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+
+# The install script is based off of the Apache 2.0 licensed script from Helm,
+# the Kubernetes resouce manager: https://github.com/helm/helm.
+
+GITHUB_REPOSITORY="nobl9/sloctl"
+
+: "${BINARY_NAME:="sloctl"}"
+: "${USE_SUDO:="true"}"
+: "${DEBUG:="false"}"
+: "${VERIFY_CHECKSUM:="true"}"
+: "${VERIFY_SIGNATURES:="false"}"
+: "${SLOCTL_INSTALL_DIR:="/usr/local/bin"}"
+
+HAS_CURL="$(type "curl" &>/dev/null && echo true || echo false)"
+HAS_WGET="$(type "wget" &>/dev/null && echo true || echo false)"
+HAS_OPENSSL="$(type "openssl" &>/dev/null && echo true || echo false)"
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+  armv5*) ARCH="armv5" ;;
+  armv6*) ARCH="armv6" ;;
+  armv7*) ARCH="arm" ;;
+  aarch64) ARCH="arm64" ;;
+  x86) ARCH="386" ;;
+  x86_64) ARCH="amd64" ;;
+  i686) ARCH="386" ;;
+  i386) ARCH="386" ;;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(uname | tr '[:upper:]' '[:lower:]')
+
+  case "$OS" in
+  # Minimalist GNU for Windows
+  mingw* | cygwin*) OS='windows' ;;
+  esac
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+  if [ $EUID -ne 0 ] && [ "$USE_SUDO" = "true" ]; then
+    sudo "${@}"
+  else
+    "${@}"
+  fi
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds, as well whether or not necessary tools are present.
+verifySupported() {
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-amd64\nlinux-arm64\nwindows-amd64\nwindows-arm64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuilt binary for ${OS}-${ARCH}."
+    echo "To build from source, go to https://github.com/$GITHUB_REPOSITORY"
+    exit 1
+  fi
+
+  if [ "${HAS_CURL}" != "true" ] && [ "${HAS_WGET}" != "true" ]; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+
+  if [ "${VERIFY_CHECKSUM}" == "true" ] && [ "${HAS_OPENSSL}" != "true" ]; then
+    echo "In order to verify checksum, openssl must first be installed."
+    echo "Please install openssl or set VERIFY_CHECKSUM=false in your environment."
+    exit 1
+  fi
+}
+
+# checkLatestVersion checks if the desired version is available.
+checkLatestVersion() {
+  if [ "$DESIRED_VERSION" == "" ]; then
+    # Get tag from release URL
+    local latest_release_url="https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest"
+    local response=""
+    if [ "${HAS_CURL}" == "true" ]; then
+      response=$(curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true)
+    elif [ "${HAS_WGET}" == "true" ]; then
+      response=$(wget "$latest_release_url" -q -O - 2>&1 || true)
+    fi
+    if [[ $response =~ \"tag_name\":\ \"([^\"]+)\" ]]; then
+      TAG="${BASH_REMATCH[1]}"
+    fi
+    if [ "$TAG" == "" ]; then
+      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${response}"
+      exit 1
+    fi
+  else
+    TAG=$DESIRED_VERSION
+  fi
+}
+
+# checkSloctlInstalledVersion checks which version of sloctl is installed and
+# if it needs to be changed.
+checkSloctlInstalledVersion() {
+  if [[ -f "${SLOCTL_INSTALL_DIR}/${BINARY_NAME}" ]]; then
+    local version
+    version=$("${SLOCTL_INSTALL_DIR}/${BINARY_NAME}" version)
+    if [[ $version =~ sloctl/([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+      version="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$version" == "$TAG" ]]; then
+      echo "Sloctl ${version} is already ${DESIRED_VERSION:-latest}"
+      return 0
+    else
+      echo "Sloctl ${TAG} is available. Changing from version ${version}."
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  SLOCTL_DIST="sloctl-$TAG-$OS-$ARCH"
+  DOWNLOAD_BASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG"
+  DOWNLOAD_URL="$DOWNLOAD_BASE_URL/$SLOCTL_DIST"
+  CHECKSUM_URL="$DOWNLOAD_BASE_URL/sloctl-$TAG.sha256"
+  SLOCTL_TMP_ROOT="$(mktemp -dt sloctl-installer-XXXXXX)"
+  SLOCTL_TMP_BIN="$SLOCTL_TMP_ROOT/sloctl"
+  SLOCTL_SUM_FILE="$SLOCTL_TMP_ROOT/sloctl-$TAG.sha256"
+  echo "Downloading $DOWNLOAD_URL"
+  if [ "${HAS_CURL}" == "true" ]; then
+    curl -SsL --fail "$DOWNLOAD_URL" -o "$SLOCTL_TMP_BIN"
+  elif [ "${HAS_WGET}" == "true" ]; then
+    wget -q -O "$SLOCTL_TMP_BIN" "$DOWNLOAD_URL"
+  fi
+  echo "Downloading checksum $CHECKSUM_URL"
+  if [ "${HAS_CURL}" == "true" ]; then
+    curl -SsL --fail "$CHECKSUM_URL" -o "$SLOCTL_SUM_FILE"
+  elif [ "${HAS_WGET}" == "true" ]; then
+    wget -q -O "$SLOCTL_SUM_FILE" "$CHECKSUM_URL"
+  fi
+}
+
+# verifyFile verifies the SHA256 checksum of the binary package
+# and the GPG signatures for both the package and checksum file
+# (depending on settings in environment).
+verifyFile() {
+  if [ "${VERIFY_CHECKSUM}" == "true" ]; then
+    verifyChecksum
+  fi
+}
+
+# installFile installs the sloctl binary.
+installFile() {
+  echo "Preparing to install $BINARY_NAME into ${SLOCTL_INSTALL_DIR}"
+  runAsRoot cp "$SLOCTL_TMP_BIN" "$SLOCTL_INSTALL_DIR/$BINARY_NAME"
+  echo "$BINARY_NAME installed into $SLOCTL_INSTALL_DIR/$BINARY_NAME"
+}
+
+# verifyChecksum verifies the SHA256 checksum of the binary package.
+verifyChecksum() {
+  printf "Verifying checksum... "
+  local actual_sum
+  local expected_sum
+  actual_sum=$(openssl sha1 -sha256 "${SLOCTL_TMP_BIN}" | awk '{print $2}')
+  expected_sum=$(cat "${SLOCTL_SUM_FILE}")
+  if [ "$actual_sum" != "$expected_sum" ]; then
+    echo "SHA sum of ${SLOCTL_TMP_BIN} does not match. Aborting."
+    exit 1
+  fi
+  echo "Done."
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    if [[ -n "$INPUT_ARGUMENTS" ]]; then
+      echo "Failed to install $BINARY_NAME with the arguments provided: $INPUT_ARGUMENTS"
+      help
+    else
+      echo "Failed to install $BINARY_NAME"
+    fi
+    echo -e "\tFor support, go to https://github.com/nobl9/sloctl."
+  fi
+  cleanup
+  exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+  set +e
+  command -v "$BINARY_NAME"
+  if [ "$?" = "1" ]; then
+    echo "$BINARY_NAME not found. Is $SLOCTL_INSTALL_DIR on your '\$PATH?'"
+    exit 1
+  fi
+  set -e
+}
+
+# help provides possible cli installation arguments
+help() {
+  echo "Accepted cli arguments are:"
+  echo -e "\t[--help|-h ] ->> prints this help"
+  echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub"
+  echo -e "\te.g. --version v0.10.0"
+  echo -e "\t[--no-sudo]  ->> install without sudo"
+}
+
+cleanup() {
+  if [[ -d "${SLOCTL_TMP_ROOT:-}" ]]; then
+    rm -rf "$SLOCTL_TMP_ROOT"
+  fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+set -e
+
+# Set debug if desired
+if [ "${DEBUG}" == "true" ]; then
+  set -x
+fi
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${*}"
+set -u
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  '--version' | -v)
+    shift
+    if [[ $# -ne 0 ]]; then
+      export DESIRED_VERSION="${1}"
+      if [[ "$1" != "v"* ]]; then
+        echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
+        export DESIRED_VERSION="v${1}"
+      fi
+    else
+      echo -e "Please provide the desired version. e.g. --version v0.10.0"
+      exit 0
+    fi
+    ;;
+  '--no-sudo')
+    USE_SUDO="false"
+    ;;
+  '--help' | -h)
+    help
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+  esac
+  shift
+done
+set +u
+
+initArch
+initOS
+verifySupported
+checkLatestVersion
+if ! checkSloctlInstalledVersion; then
+  downloadFile
+  verifyFile
+  installFile
+fi
+testVersion
+cleanup

--- a/install.bash
+++ b/install.bash
@@ -2,7 +2,7 @@
 
 # The install script is based on the Apache 2.0 licensed script from Helm,
 # the Kubernetes resource manager: https://github.com/helm/helm.
-# Original script from Helm: 
+# Original script from Helm:
 #   https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 
 PROGRAM_NAME="sloctl"
@@ -158,7 +158,7 @@ downloadFile() {
   fi
 }
 
-# installFile installs the prgoram binary.
+# installFile installs the program binary.
 installFile() {
   echo "Preparing to install ${PROGRAM_NAME} into ${PROGRAM_INSTALL_DIR}"
   runAsRoot cp "$PROGRAM_TMP_BIN" "${PROGRAM_INSTALL_DIR}/${PROGRAM_NAME}"
@@ -197,7 +197,7 @@ fail_trap() {
 
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
-  if ! command -v "$PROGRAM_NAME" &> /dev/null; then
+  if ! command -v "$PROGRAM_NAME" &>/dev/null; then
     echo "${PROGRAM_NAME} not found. Is ${PROGRAM_INSTALL_DIR} on your '\$PATH?'"
     exit 1
   fi

--- a/install.bash
+++ b/install.bash
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 # The install script is based off of the Apache 2.0 licensed script from Helm,
-# the Kubernetes resouce manager: https://github.com/helm/helm.
+# the Kubernetes resource manager: https://github.com/helm/helm.
 
-GITHUB_REPOSITORY="nobl9/sloctl"
+PROGRAM_NAME="sloctl"
+GITHUB_REPOSITORY="nobl9/$PROGRAM_NAME"
 
-: "${BINARY_NAME:="sloctl"}"
+: "${BINARY_NAME:=$PROGRAM_NAME}"
 : "${USE_SUDO:="true"}"
 : "${DEBUG:="false"}"
 : "${VERIFY_CHECKSUM:="true"}"
-: "${VERIFY_SIGNATURES:="false"}"
 : "${SLOCTL_INSTALL_DIR:="/usr/local/bin"}"
 
 HAS_CURL="$(type "curl" &>/dev/null && echo true || echo false)"
@@ -197,33 +197,48 @@ testVersion() {
   set -e
 }
 
-# help provides possible cli installation arguments
+# help provides possible cli installation arguments.
 help() {
-  echo "Accepted cli arguments are:"
-  echo -e "\t[--help|-h ] ->> prints this help"
-  echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub"
-  echo -e "\te.g. --version v0.10.0"
-  echo -e "\t[--no-sudo]  ->> install without sudo"
+  local script_name
+  script_name=$(basename "$0")
+  cat >&2 <<EOF
+  Usage: ${script_name} [OPTS]
+An installer script for ${PROGRAM_NAME}!
+It can be used to both install the binary and upgrade an existing ${PROGRAM_NAME} version.
+OPTS:
+  -h, --help                          Print this message
+  --version, -v <desired_version>     When not defined it fetches the latest release from GitHub
+  --no-sudo                           Install without sudo
+ENV VARIABLES:
+  BINARY_NAME           Installed binary name, defaults to ${PROGRAM_NAME}
+  USE_SUDO              Whether to install with sudo, defaults to true
+  DEBUG                 Print additional debug information, defaults to false
+  VERIFY_CHECKSUM       Verify the SHA256 checksum of the binary, defaults to true
+  SLOCTL_INSTALL_DIR    Install directory, defaults to /usr/local/bin
+Examples:
+  SLOCTL_INSTALL_DIR=/home/me/go/bin ${script_name} --no-sudo --version=v0.10.0
+EOF
 }
 
+# cleanup temporary files.
 cleanup() {
   if [[ -d "${SLOCTL_TMP_ROOT:-}" ]]; then
     rm -rf "$SLOCTL_TMP_ROOT"
   fi
 }
 
-# Execution
+# Execution.
 
-#Stop execution on any error
+# Stop execution on any error.
 trap "fail_trap" EXIT
 set -e
 
-# Set debug if desired
+# Set debug if desired.
 if [ "${DEBUG}" == "true" ]; then
   set -x
 fi
 
-# Parsing input arguments (if any)
+# Parsing input arguments (if any).
 export INPUT_ARGUMENTS="${*}"
 set -u
 while [[ $# -gt 0 ]]; do
@@ -256,6 +271,7 @@ while [[ $# -gt 0 ]]; do
 done
 set +u
 
+# Run.
 initArch
 initOS
 verifySupported

--- a/install.bash
+++ b/install.bash
@@ -150,16 +150,16 @@ downloadFile() {
 
   echo "Downloading ${DOWNLOAD_URL}"
   if [ "$HAS_CURL" == "true" ]; then
-    curl -SsL --fail "$DOWNLOAD_URL" -o "$PROGRAM_TMP_BIN"
+    curl -SsL --fail "$DOWNLOAD_URL" -o - > "$PROGRAM_TMP_BIN"
   elif [ "$HAS_WGET" == "true" ]; then
-    wget -q -O "$PROGRAM_TMP_BIN" "$DOWNLOAD_URL"
+    wget -q -O - "$DOWNLOAD_URL" > "$PROGRAM_TMP_BIN"
   fi
 
   echo "Downloading checksum $CHECKSUM_URL"
   if [ "$HAS_CURL" == "true" ]; then
-    curl -SsL --fail "$CHECKSUM_URL" -o "$PROGRAM_SUM_FILE"
+    curl -SsL --fail "$CHECKSUM_URL" -o - > "$PROGRAM_SUM_FILE"
   elif [ "$HAS_WGET" == "true" ]; then
-    wget -q -O "$PROGRAM_SUM_FILE" "$CHECKSUM_URL"
+    wget -q -O - "$CHECKSUM_URL" > "$PROGRAM_SUM_FILE"
   fi
 }
 

--- a/test/docker/Dockerfile.unit
+++ b/test/docker/Dockerfile.unit
@@ -1,12 +1,13 @@
 FROM bats/bats:1.11.1
 
 RUN apk --no-cache --update add \
-  gettext jq git python3 py3-pip
+  gettext jq git python3 py3-pip openssl
 RUN pip install yq==v3.2.3 --break-system-packages
 
 WORKDIR /sloctl
 
 COPY ./test ./test
+COPY ./install.bash ./install.bash
 COPY --from=sloctl-unit-test-bin /usr/bin/sloctl /usr/bin/sloctl
 
 # Required for bats pretty printing.

--- a/test/install-script.bats
+++ b/test/install-script.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# bats file_tags=unit
+
+# setup_file is run only once for the whole file.
+setup_file() {
+  load "test_helper/load"
+
+  ensure_installed openssl
+
+  run cp /usr/bin/sloctl /usr/bin/sloctl-backup
+}
+
+# teardown_file is run only once for the whole file.
+teardown_file() {
+  run mv /usr/bin/sloctl-backup /usr/bin/sloctl
+  run rm /usr/local/bin/sloctl
+}
+
+# setup is run before each test.
+setup() {
+  load "test_helper/load"
+  load_lib "bats-assert"
+  load_lib "bats-support"
+}
+
+@test "display help message" {
+  run ./install.bash --help
+  assert_success
+  assert_output --partial 'Usage: install.bash'
+}
+
+@test "install in default location" {
+  run ./install.bash -v v0.11.0-rc1
+  assert_success
+
+  run /usr/local/bin/sloctl version
+  assert_success
+  assert_output 'sloctl/0.11.0-rc1-HEAD-bc9f5fd (linux amd64 go1.23.6)'
+}
+
+@test "install in custom location in the PATH" {
+  run ./install.bash -v v0.11.0-rc1 -d /usr/bin
+  assert_success
+
+  run /usr/bin/sloctl version
+  assert_success
+  assert_output 'sloctl/0.11.0-rc1-HEAD-bc9f5fd (linux amd64 go1.23.6)'
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -2,7 +2,7 @@ setup_suite() {
 	load "test_helper/load"
 
   # General dependencies shared by all tests.
-  ensure_installed jq git sloctl
+  ensure_installed jq git sloctl yq
 
   export TEST_SUITE_OUTPUTS="$BATS_TEST_DIRNAME/outputs"
   export TEST_SUITE_INPUTS="$BATS_TEST_DIRNAME/inputs"


### PR DESCRIPTION
## Motivation

Currently we're only building binaries for amd64 architecture, it would be good to support arm64 as well.
In addition, many tools often provide an install script which automates the process of installing/upgrading these tools.

## Testing

Run install script:

```bash
./install.bash -v v0.11.0-rc1 -d <YOUR_PATH>
```

You can also test the commands for installment from README, for instance:

```bash
curl -fsSL -o install.bash https://raw.githubusercontent.com/nobl9/sloctl/extend-release-targets-and-add-install-script/install.bash
```

## Release Notes

Sloctl pre-built binaries are now also built for arm64 architecture.
In addition there's now a now method of installing sloctl, via an install script.
For more details refer to the [README](https://github.com/nobl9/sloctl/tree/main?tab=readme-ov-file#script).

## Breaking Changes

Sloctl released binaries are no longer of a form _sloctl-${OS}-${VERSION}_ (e.g. `sloctl-linux-0.10.1`), instead they now follow this pattern: _sloctl-${VERSION}-${OS}-${ARCH} (e.g. `sloctl-0.11.0-linux-adm64`).
In addition, the checksum for each release is changing it's name from _sloctl-${VERSION}-SHA256SUMS to _sloctl-${VERSION}.sha256_.
