### PR TITLE
fix: Update Homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ brews:
       assert_predicate bin/"{{ .ProjectName }}", :exist?
       system "{{ .ProjectName }}", "--help"
     install: |
-      bin.install Dir['{{ .ProjectName }}-*-{{ .Version }}'].first()  => "{{ .ProjectName }}"
+      bin.install Dir['{{ .ProjectName }}-{{ .Version }}-*'].first()  => "{{ .ProjectName }}"
     caveats: |
       Thank you for installing the command-line client for Nobl9!
 


### PR DESCRIPTION
Changes introduced in https://github.com/nobl9/sloctl/pull/288 broke this glob pattern:

```ruby
bin.install Dir['sloctl-*-0.11.0'].first()  => "sloctl"
```

Since this is not a regular expression but a glob pattern, the newly added arch suffix (and the moved OS name) failed to match.