### PR TITLE
chore: Enable token caching for e2e tests

### DIFF
--- a/test/docker/Dockerfile.e2e
+++ b/test/docker/Dockerfile.e2e
@@ -9,6 +9,5 @@ WORKDIR /sloctl
 COPY ./test ./test
 COPY --from=sloctl-e2e-test-bin /usr/bin/sloctl /usr/bin/sloctl
 
-ENV SLOCTL_NO_CONFIG_FILE=false
 # Required for bats pretty printing.
 ENV TERM=linux

--- a/test/docker/Dockerfile.e2e
+++ b/test/docker/Dockerfile.e2e
@@ -9,6 +9,6 @@ WORKDIR /sloctl
 COPY ./test ./test
 COPY --from=sloctl-e2e-test-bin /usr/bin/sloctl /usr/bin/sloctl
 
-ENV SLOCTL_NO_CONFIG_FILE=true
+ENV SLOCTL_NO_CONFIG_FILE=false
 # Required for bats pretty printing.
 ENV TERM=linux


### PR DESCRIPTION
## Motivation

To reduce token requests we decided to enable use the same config between tests. 

