### PR TITLE
feat: Add cancellation field to replay list response

### DIFF
--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -21,13 +21,14 @@ func (r *ReplayCmd) AddListCommand() *cobra.Command {
 	return cmd
 }
 
-type ReplayQueueItem struct {
+type ReplayListItem struct {
 	Slo            string `json:"slo,omitempty"`
 	Project        string `json:"project"`
 	ElapsedTime    string `json:"elapsedTime,omitempty"`
 	RetrievedScope string `json:"retrievedScope,omitempty"`
 	RetrievedFrom  string `json:"retrievedFrom,omitempty"`
 	Status         string `json:"status"`
+	Cancellation   string `json:"cancellation,omitempty"`
 }
 
 func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
@@ -45,7 +46,7 @@ func (r *ReplayCmd) listAllReplays(cmd *cobra.Command) error {
 		return err
 	}
 
-	var replayQueueList []ReplayQueueItem
+	var replayQueueList []ReplayListItem
 	if err := json.Unmarshal(response, &replayQueueList); err != nil {
 		fmt.Printf("err: %v\n", err)
 	}


### PR DESCRIPTION
## Motivation

The ability to cancel replays when they are in the importing phase is in development. New action will be available in both UI and sloctl.

## Summary

This pull request includes a renaming of a struct and the addition of a new field to improve clarity and functionality in the replay list feature.

### Struct renaming and enhancement:

* Renamed the `ReplayQueueItem` struct to `ReplayListItem` for better alignment with its purpose in the replay list context. (`internal/replay_list.go`, [internal/replay_list.goL24-R31](diffhunk://#diff-73224e3f4249a9b4533174b18bdabf4cdbaf00f507d9116c78d48b9e40c27c57L24-R31))
* Added a new field `Cancellation` (of type `string`) to the `ReplayListItem` struct to capture cancellation-related information. (`internal/replay_list.go`, [internal/replay_list.goL24-R31](diffhunk://#diff-73224e3f4249a9b4533174b18bdabf4cdbaf00f507d9116c78d48b9e40c27c57L24-R31))

### Code adjustments for the renamed struct:

* Updated the variable type in the `listAllReplays` function to use the renamed `ReplayListItem` struct instead of the old `ReplayQueueItem`. (`internal/replay_list.go`, [internal/replay_list.goL48-R49](diffhunk://#diff-73224e3f4249a9b4533174b18bdabf4cdbaf00f507d9116c78d48b9e40c27c57L48-R49))

## Related changes

https://github.com/nobl9/n9/pull/17808

## Testing

```bash
sloctl replay list
```
```yaml
- slo: cancel-test-4
  project: prometheus
  elapsedTime: 2m0s
  retrievedScope: 13 Day
  retrievedFrom: "2025-04-30T23:55:34Z"
  status: in progress
  cancellation: possible
- slo: cancel-test
  project: prometheus
  elapsedTime: 2m0s
  retrievedScope: 13 Day
  retrievedFrom: "2025-04-30T23:55:28Z"
  status: in progress
  cancellation: possible
- slo: cancel-test-3
  project: prometheus
  elapsedTime: 2m0s
  retrievedScope: 13 Day
  retrievedFrom: "2025-04-30T23:55:32Z"
  status: queued
  cancellation: blocked
```

## Release Notes

The output of `sloctl replay list` now has a new `cancellation` field, which contains information about the availability and status of the cancellation of the replay.

