### PR TITLE
fix: correct object printing logic and budget adjustment flags handling

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -42,6 +42,11 @@ func registerAutoConfirmationFlag(cmd *cobra.Command, storeIn *bool) {
 			" Threshold can be changed or disabled in config.toml or via env variables.")
 }
 
+func registerProjectFlag(cmd *cobra.Command, storeIn *string) {
+	cmd.Flags().StringVarP(storeIn, "project", "p", "",
+		`List the requested object(s) which belong to the specified Project (name).`)
+}
+
 var projectFlagSupportingKinds = map[manifest.Kind]struct{}{
 	manifest.KindSLO:          {},
 	manifest.KindService:      {},

--- a/test/adjustments-e2e.bats
+++ b/test/adjustments-e2e.bats
@@ -37,10 +37,3 @@ setup() {
     assert_output "Error: - adjustment 'foo' was not found"
   done
 }
-
-@test "adjustment not found" {
-  run_sloctl budgetadjustments get abc-123
-  assert_failure
-  output="$stderr"
-  assert_output "No resources found."
-}

--- a/test/adjustments-e2e.bats
+++ b/test/adjustments-e2e.bats
@@ -24,7 +24,7 @@ setup() {
   assert_output "Error: - 'to' date must be be after 'from' date (source: 'to', value: '{\"Adjustment\":\"foo\",\"From\":\"${from}\",\"To\":\"2024-01-01T00:00:00Z\",\"SloProject\":\"\",\"SloNa...')"
 }
 
-@test "adjustment not found" {
+@test "adjustment event not found" {
   run_sloctl budgetadjustments events get --adjustment-name=foo --from=2024-01-01T00:00:00Z --to=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   assert_failure
   output="$stderr"
@@ -36,4 +36,11 @@ setup() {
     output="$stderr"
     assert_output "Error: - adjustment 'foo' was not found"
   done
+}
+
+@test "adjustment event not found" {
+  run_sloctl budgetadjustments get abc-123
+  assert_failure
+  output="$stderr"
+  assert_output "No resources found."
 }

--- a/test/adjustments-e2e.bats
+++ b/test/adjustments-e2e.bats
@@ -38,7 +38,7 @@ setup() {
   done
 }
 
-@test "adjustment event not found" {
+@test "adjustment not found" {
   run_sloctl budgetadjustments get abc-123
   assert_failure
   output="$stderr"

--- a/test/adjustments-e2e.bats
+++ b/test/adjustments-e2e.bats
@@ -24,7 +24,7 @@ setup() {
   assert_output "Error: - 'to' date must be be after 'from' date (source: 'to', value: '{\"Adjustment\":\"foo\",\"From\":\"${from}\",\"To\":\"2024-01-01T00:00:00Z\",\"SloProject\":\"\",\"SloNa...')"
 }
 
-@test "adjustment event not found" {
+@test "get events for non-existent adjustment" {
   run_sloctl budgetadjustments events get --adjustment-name=foo --from=2024-01-01T00:00:00Z --to=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   assert_failure
   output="$stderr"


### PR DESCRIPTION
## Motivation

Changes introduced in https://github.com/nobl9/sloctl/pull/361 have broken how `sloctl get agent` is printing "no resources message", i.e. it's not printing anything now.
This PR fixes the issue, in addition `sloctl get budgetadjustment`, when finding no resource will print `No resources found.` instead of specifying the project. The command in its bare form is not project aware and should not have been printing such message indicating so, while it has `-p` filter, it can only be used in conjunction with `--slo` flag.

## Summary

Introduces a new helper function `registerProjectFlag` to centralize the registration of the `--project` flag. This reduces code duplication across multiple commands. The function is now used in various places where the `--project` flag was previously registered manually.

Additionally, a new method `printObjects` has been added to the `GetCmd` struct. This method encapsulates the logic for printing objects, including handling cases where no objects are found. The method also ensures consistent messaging based on whether the `--project` flag is supported for the given object kind. This change simplifies the `RunE` implementations of commands by removing repetitive code for handling empty object lists and delegating the printing responsibility to the new method.

These changes improve code maintainability and readability by reducing redundancy and centralizing common logic.

## Testing

End-to-end tests dispatch: https://github.com/nobl9/sloctl/actions/runs/16773965200
