### PR TITLE
fix: Update error messages for invalid date format tests

### DIFF
--- a/internal/flags/timevalue.go
+++ b/internal/flags/timevalue.go
@@ -8,8 +8,8 @@ import (
 type TimeValue struct{ time.Time }
 
 const (
-	TimeLayout       = time.RFC3339
-	TimeLayoutString = "RFC3339"
+	TimeLayout     = time.RFC3339
+	TimeLayoutName = "RFC3339"
 )
 
 func (t *TimeValue) String() string {
@@ -22,7 +22,9 @@ func (t *TimeValue) String() string {
 func (t *TimeValue) Set(s string) error {
 	var err error
 	if t.Time, err = time.Parse(TimeLayout, s); err != nil {
-		return fmt.Errorf("date does not match '%s' layout (%s)", TimeLayout, TimeLayoutString)
+		return fmt.Errorf(
+			"date does not match %s layout (e.g. '2006-01-02T15:04:05Z' or '2006-01-02T08:04:05-07:00')",
+			TimeLayoutName)
 	}
 	return nil
 }

--- a/internal/replay_errors.go
+++ b/internal/replay_errors.go
@@ -21,7 +21,7 @@ var (
 	errReplayTooManyArgs = errors.New("'replay' command accepts a single SLO name." +
 		" If you want to run it for multiple SLOs provide a configuration file instead using '-f' flag")
 	errReplayMissingFromArg = errors.Errorf("when running 'sloctl replay' for a single SLO,"+
-		" you must provide Replay window start time (%s layout) with '--from' flag", flags.TimeLayoutString)
+		" you must provide Replay window start time (%s layout) with '--from' flag", flags.TimeLayoutName)
 	errProjectWildcardIsNotAllowed = errors.New(
 		"wildcard Project is not allowed, you must provide specific Project name(s)")
 )

--- a/test/adjustments-unit.bats
+++ b/test/adjustments-unit.bats
@@ -31,11 +31,11 @@ setup() {
 @test "invalid date format" {
   run_sloctl budgetadjustments events get --adjustment-name=foo --from=xyz --to=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   assert_failure
-  assert_stderr "Error: invalid argument \"xyz\" for \"--from\" flag: date does not match '2006-01-02T15:04:05Z07:00' layout (RFC3339)"
+  assert_stderr "Error: invalid argument \"xyz\" for \"--from\" flag: date does not match RFC3339 layout (e.g. '2006-01-02T15:04:05Z' or '2006-01-02T08:04:05-07:00')"
 
   run_sloctl budgetadjustments events get --adjustment-name=foo --to=xyz --from=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   assert_failure
-  assert_stderr "Error: invalid argument \"xyz\" for \"--to\" flag: date does not match '2006-01-02T15:04:05Z07:00' layout (RFC3339)"
+  assert_stderr "Error: invalid argument \"xyz\" for \"--to\" flag: date does not match RFC3339 layout (e.g. '2006-01-02T15:04:05Z' or '2006-01-02T08:04:05-07:00')"
 }
 
 @test "conditionally required arguments (slo-project and slo-name)" {


### PR DESCRIPTION
## Motivation

Improve error message to clarify what date formats are valid to use with this feature.

## Summary

Included better examples of valid date formats.

## Testing

This change only affects error messages. I have not tested it.

## Release Notes

Included better examples of valid date formats for `sloctl budgetadjustments events get` `--from` and `--to` flags.