### PR TITLE
chore: adjust indentation format in release notes script

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -32,7 +32,7 @@ extract_header() {
 
 indent() {
 	while IFS= read -r line; do
-		printf "  %s\n" "${line%"${line##*[![:space:]]}"}"
+		printf "  > %s\n" "${line%"${line##*[![:space:]]}"}"
 	done <<<"$1"
 }
 
@@ -59,7 +59,7 @@ while IFS= read -r line; do
 	add_notes() {
 		local notes="$1"
 		if [[ $notes != "" ]]; then
-			new_notes+=$(indent "> $notes")
+			new_notes+=$(indent "$notes")
 			new_notes+="\n"
 		fi
 	}


### PR DESCRIPTION
## Motivation

If we preface every line with `>` quotation mark, then we can be sure no markdown formatting will mess up the resulting release notes.
