### PR TITLE
chore: fix invalid time usage in Budget Adjustments (pre-release)

### DIFF
--- a/internal/budgetadjustments/events/delete.go
+++ b/internal/budgetadjustments/events/delete.go
@@ -53,11 +53,11 @@ func (g *DeleteCmd) run(cmd *cobra.Command) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to convert input data to JSON")
 		}
-		if _, err = DoRequest(
+		if _, err = doRequest(
 			g.client,
 			cmd.Context(),
 			http.MethodPost,
-			fmt.Sprintf("%s/%s/events/delete", BudgetAdjustmentAPI, g.adjustment),
+			fmt.Sprintf("%s/%s/events/delete", budgetAdjustmentAPI, g.adjustment),
 			nil,
 			bytes.NewReader(jsonBytes),
 		); err != nil {

--- a/internal/budgetadjustments/events/get.go
+++ b/internal/budgetadjustments/events/get.go
@@ -72,7 +72,10 @@ func NewGetCmd(clientProvider sdkclient.SdkClientProvider) *cobra.Command {
 }
 
 func (g *GetCmd) run(cmd *cobra.Command) error {
-	values := url.Values{"from": {g.from.String()}, "to": {g.to.String()}}
+	values := url.Values{
+		"from": {g.from.Format(time.RFC3339)},
+		"to":   {g.to.Format(time.RFC3339)},
+	}
 	if g.sloName != "" {
 		values.Add("sloName", g.sloName)
 	}
@@ -80,11 +83,11 @@ func (g *GetCmd) run(cmd *cobra.Command) error {
 		values.Add("sloProject", g.project)
 	}
 
-	resBody, err := DoRequest(
+	resBody, err := doRequest(
 		g.client,
 		cmd.Context(),
 		http.MethodGet,
-		fmt.Sprintf("%s/%s/events", BudgetAdjustmentAPI, g.adjustment),
+		fmt.Sprintf("%s/%s/events", budgetAdjustmentAPI, g.adjustment),
 		values,
 		nil,
 	)

--- a/internal/budgetadjustments/events/request.go
+++ b/internal/budgetadjustments/events/request.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const BudgetAdjustmentAPI = "/budgetadjustments/v1"
+const budgetAdjustmentAPI = "/budgetadjustments/v1"
 
-func DoRequest(
+func doRequest(
 	client *sdk.Client,
 	ctx context.Context,
 	method, endpoint string,

--- a/internal/budgetadjustments/events/update.go
+++ b/internal/budgetadjustments/events/update.go
@@ -53,11 +53,11 @@ func (g *UpdateCmd) run(cmd *cobra.Command) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to convert input data to JSON")
 		}
-		_, err = DoRequest(
+		_, err = doRequest(
 			g.client,
 			cmd.Context(),
 			http.MethodPut,
-			fmt.Sprintf("%s/%s/events/update", BudgetAdjustmentAPI, g.adjustment),
+			fmt.Sprintf("%s/%s/events/update", budgetAdjustmentAPI, g.adjustment),
 			nil,
 			bytes.NewReader(jsonBytes),
 		)

--- a/test/adjustments-e2e.bats
+++ b/test/adjustments-e2e.bats
@@ -16,15 +16,15 @@ setup() {
   load_lib "bats-assert"
 }
 
-@test "date to is before from" {
-  from=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  run_sloctl budgetadjustments events get --adjustment-name=foo --to=2024-01-01T00:00:00Z --from=$from
+@test "date 'to' is before 'from'" {
+  from="2024-01-02T00:00:00Z"
+  run_sloctl budgetadjustments events get --adjustment-name=foo --from="$from" --to=2024-01-01T00:00:00Z
   assert_failure
   assert_stderr "Error: - 'to' date must be be after 'from' date (source: 'to', value: '{\"Adjustment\":\"foo\",\"From\":\"${from}\",\"To\":\"2024-01-01T00:00:00Z\",\"SloProject\":\"\",\"SloNa...')"
 }
 
 @test "get events for non-existent adjustment" {
-  run_sloctl budgetadjustments events get --adjustment-name=foo --from=2024-01-01T00:00:00Z --to=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  run_sloctl budgetadjustments events get --adjustment-name=foo --from=2024-01-01T00:00:00Z --to=2024-01-02T00:00:00Z
   assert_failure
   assert_stderr "Error: - adjustment 'foo' was not found"
 


### PR DESCRIPTION
## Motivation

`flags.TimeValue` refactor introduced in https://github.com/nobl9/sloctl/pull/396 has broken `BudgetAdjustments` code as they silently depended on `fmt.Stringer` interface and used its `String()` method to write `from` and `to` query params.
The previous implementation used `flags.TimeValue` directly as the flags' value storage, but after these changes, the value is stored directly in `time.Time` which `String()` implementation returns ISO format instead of RFC3339.

