### PR TITLE
chore: fix move SLO e2e tests

### DIFF
--- a/test/move-e2e.bats
+++ b/test/move-e2e.bats
@@ -15,7 +15,8 @@ setup_file() {
 
 # teardown_file is run only once for the whole file.
 teardown_file() {
-  run_sloctl delete -f "'$TEST_INPUTS/**'" -f "'$TEST_OUTPUTS/**'"
+  run_sloctl delete -f "'$TEST_INPUTS/**'"
+  run_sloctl delete -f "'$TEST_OUTPUTS/**'"
   assert_success_joined_output
 }
 


### PR DESCRIPTION
## Motivation

Fix move e2e tests tear down.

```
move-e2e.bats
 ✓ default source Project
 ✓ custom source Project
 ✓ move multiple slos
 ✓ move all slos from Project
 ✓ custom target Service
 ✓ same-project service move
 ✓ same-project service move with multiple slos
 ✓ error for attached Alert Policies
 ✓ detach Alert Policies
 ✓ no SLOs in source Project
 ✗ teardown_file failed
   (from function `assert_success' in file /usr/lib/bats/bats-assert/src/assert_success.bash, line 42,
    from function `assert_success_joined_output' in file test/test_helper/load.bash, line 259,
    from function `teardown_file' in test file test/move-e2e.bats, line 19)
     `assert_success_joined_output' failed

   -- command failed --
   status : 1
   output (21 lines):
     Deleting 32 objects from the following sources:
      - /sloctl/test/outputs/move-e2e/custom-project.yaml
      - /sloctl/test/outputs/move-e2e/custom-target-service.yaml
      - /sloctl/test/outputs/move-e2e/default-project.yaml
      - /sloctl/test/outputs/move-e2e/dependencies.yaml
      - /sloctl/test/outputs/move-e2e/detach-alert-policies.yaml
      - /sloctl/test/outputs/move-e2e/move-all-slos.yaml
      - /sloctl/test/outputs/move-e2e/move-multiple-slos.yaml
      - /sloctl/test/outputs/move-e2e/same-project-multi.yaml
      - /sloctl/test/outputs/move-e2e/same-project-service-move.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/custom-project.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/custom-target-service.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/default-project.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/dependencies.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/detach-alert-policies-error.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/detach-alert-policies.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/move-all-slos.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/move-multiple-slos.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/same-project-multi.yaml
      - /tmp/bats-run-hpnMLk/file/13/move-e2e/same-project-service-move.yaml
     Error: Bad Request: constraint "SLO.metadata.name has to be unique across a single Project" was violated due to the following conflicts: [{"Project": "e2e--1-1768297487-057c100a", "SLO": "same-project-multi-1"}, {"Project": "e2e--1-1768297487-057c100a", "SLO": "same-project-multi-2"}, {"Project": "e2e--1-1768297487-057c100a", "SLO": "same-project-service-move"}] (code: 400, endpoint: DELETE https://dev-demo-1.nobl9.dev/api/delete?dry_run=false, traceId: 958518366596624317)
   --

```
## Summary

```
move-e2e.bats
 ✓ default source Project
 ✓ custom source Project
 ✓ move multiple slos
 ✓ move all slos from Project
 ✓ custom target Service
 ✓ same-project service move
 ✓ same-project service move with multiple slos
 ✓ error for attached Alert Policies
 ✓ detach Alert Policies
 ✓ no SLOs in source Project
...

85 tests, 0 failures
```


