### PR TITLE
chore: add docker release recovery workflow

### DIFF
--- a/.github/workflows/release-docker-recovery.yml
+++ b/.github/workflows/release-docker-recovery.yml
@@ -1,0 +1,61 @@
+name: Release Docker Recovery
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to check out.
+        required: true
+        type: string
+        default: v0.23.0
+      version:
+        description: Docker semver tag to publish.
+        required: true
+        type: string
+        default: 0.23.0
+      shortSha:
+        description: Short commit SHA suffix for the sha-* Docker tag.
+        required: true
+        type: string
+        default: 5d90488
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Quay
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6.1.0
+        with:
+          images: |
+            nobl9/sloctl
+            quay.io/nobl9/sloctl
+          tags: |
+            type=raw,value=${{ inputs.version }}
+            type=raw,value=sha-${{ inputs.shortSha }}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v7.2.0
+        with:
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: LDFLAGS=-s -w -X github.com/nobl9/sloctl/internal.BuildVersion=v${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, qa-approval]
+    outputs:
+      dockerVersion: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout Source
         uses: actions/checkout@v6.0.3
@@ -84,7 +86,7 @@ jobs:
     with:
       clientId: ${{ vars.SLOCTL_CLIENT_ID }}
       ref: ${{ github.ref_name }}
-      sloctlImage: ${{ matrix.image }}:${{ github.ref_name }}
+      sloctlImage: ${{ matrix.image }}:${{ needs.release.outputs.dockerVersion }}
       target: test/go/e2e-docker
     secrets:
       clientSecret: "${{ secrets.SLOCTL_CLIENT_SECRET }}"


### PR DESCRIPTION
## Motivation

Version 0.23.0 has failed to publish docker images, since it's all running on a single job and goreleaser fails on already published artifacts, we need to manually trigger the docker release.

## Summary

Add a manual workflow to republish Docker images for version 0.23.0.