### PR TITLE
feat: add completion for context flag

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -528,16 +528,9 @@ sloctl config delete-context context-1 context-2`,
 }
 
 func (c *ConfigCmd) loadFileConfig(configPath string) error {
-	if configPath == "" {
-		if v, ok := os.LookupEnv(sdkEnvPrefix + "CONFIG_FILE_PATH"); ok {
-			configPath = strings.TrimSpace(v)
-		} else {
-			var err error
-			configPath, err = sdk.GetDefaultConfigPath()
-			if err != nil {
-				return err
-			}
-		}
+	configPath, err := configFilePath(configPath)
+	if err != nil {
+		return err
 	}
 	c.config = new(sdk.FileConfig)
 	if err := c.config.Load(configPath); err != nil {
@@ -547,6 +540,16 @@ func (c *ConfigCmd) loadFileConfig(configPath string) error {
 		c.config.Contexts = make(map[string]sdk.ContextConfig)
 	}
 	return nil
+}
+
+func configFilePath(configPath string) (string, error) {
+	if configPath != "" {
+		return configPath, nil
+	}
+	if v, ok := os.LookupEnv(sdkEnvPrefix + "CONFIG_FILE_PATH"); ok {
+		return strings.TrimSpace(v), nil
+	}
+	return sdk.GetDefaultConfigPath()
 }
 
 func (c *ConfigCmd) validateContextIsInUse(name string) error {

--- a/internal/root.go
+++ b/internal/root.go
@@ -3,8 +3,11 @@ package internal
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"runtime"
+	"slices"
+	"strings"
 	"sync"
 
 	v1alphaParser "github.com/nobl9/nobl9-go/manifest/v1alpha/parser"
@@ -46,6 +49,7 @@ More detailed help is available for each command.`,
 	rootCmd.PersistentFlags().StringVar(&root.Flags.ConfigFile, "config", "", "Config file path.")
 	rootCmd.PersistentFlags().StringVarP(&root.Flags.Context, "context", "c", "",
 		`Overrides the default context for the duration of the selected command.`)
+	_ = rootCmd.RegisterFlagCompletionFunc("context", root.completeContextFlag)
 	rootCmd.PersistentFlags().BoolVarP(&root.Flags.NoConfigFile, "no-config-file", "", false,
 		`Don't create config.toml, operate only on env variables.`)
 
@@ -80,6 +84,32 @@ func (r *RootCmd) GetClient() *sdk.Client {
 		}
 	})
 	return r.Client
+}
+
+func (r *RootCmd) completeContextFlag(
+	_ *cobra.Command,
+	_ []string,
+	toComplete string,
+) ([]cobra.Completion, cobra.ShellCompDirective) {
+	if r.Flags.NoConfigFile {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	configPath, err := configFilePath(r.Flags.ConfigFile)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	config := new(sdk.FileConfig)
+	if err = config.Load(configPath); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	contexts := slices.Sorted(maps.Keys(config.Contexts))
+	completions := make([]cobra.Completion, 0, len(contexts))
+	for _, contextName := range contexts {
+		if strings.HasPrefix(contextName, toComplete) {
+			completions = append(completions, contextName)
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
 }
 
 const sdkEnvPrefix = "SLOCTL_"

--- a/test/config-unit.bats
+++ b/test/config-unit.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bats file_tags=unit
 
+bats_require_minimum_version 1.5.0
+
 # setup_file is run only once for the whole file.
 setup_file() {
   CONFIG_FILENAME="config.toml"
@@ -73,6 +75,21 @@ teardown() {
   run_sloctl config current-context -o json
   assert_failure
   assert_stderr 'Error: --output flag can only be set if --verbose flag is also provided'
+}
+
+@test "sloctl --context completion lists config contexts" {
+  run --separate-stderr sloctl __complete --config "$SLOCTL_DEFAULT_CONFIG" --context ""
+  assert_success
+  assert_output 'full
+minimal
+:4'
+}
+
+@test "sloctl --context completion filters config contexts" {
+  run --separate-stderr sloctl __complete --config "$SLOCTL_DEFAULT_CONFIG" --context m
+  assert_success
+  assert_output 'minimal
+:4'
 }
 
 @test "sloctl config use-context" {


### PR DESCRIPTION
## Motivation

Context completion is a small usability improvement for users who switch between configured sloctl contexts.

## Summary

Added shell completion for the global `--context` flag by loading context names from the active sloctl config.
Shared config path resolution between config commands and completion so the flag, environment variable, and default path behave consistently.
Added Bats unit coverage for listing and prefix-filtering context completions.

## Testing

Added Bats unit tests for `--context` completion with all contexts and prefix-filtered contexts.
