### PR TITLE
feat: PC-20078 show queue time and total time in replay list

### DIFF
--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -24,7 +24,9 @@ func (r *ReplayCmd) AddListCommand() *cobra.Command {
 type ReplayListItem struct {
 	Slo            string `json:"slo,omitempty"`
 	Project        string `json:"project"`
+	QueueTime      string `json:"queueTime,omitempty"`
 	ElapsedTime    string `json:"elapsedTime,omitempty"`
+	TotalTime      string `json:"totalTime,omitempty"`
 	RetrievedScope string `json:"retrievedScope,omitempty"`
 	RetrievedFrom  string `json:"retrievedFrom,omitempty"`
 	Status         string `json:"status"`


### PR DESCRIPTION
## Motivation

The `/timetravel/list` endpoint now reports `elapsedTime` as processing-only duration and exposes two new breakdown fields, `queueTime` and `totalTime` (n9 PC-15574 / PC-20078). `sloctl replay list` should surface those fields so users can see how long a replay spent waiting in the queue versus processing, and the total wall-clock time since the request.

## Summary

Add `QueueTime` and `TotalTime` fields to `ReplayListItem` in `internal/replay_list.go`, mapped to the `queueTime` and `totalTime` JSON fields returned by the endpoint. Both are `omitempty` so older backends that do not return them render unchanged.

## Related changes

- n9: feat: PC-15574 replay elapsed time excludes queue wait (nobl9/n9#21292) - backend that populates `queueTime`, `elapsedTime`, and `totalTime`.

## Testing

1. Point `sloctl` at an environment running the n9 backend from the related PR.
2. Run `sloctl replay list` while a replay is queued and again while it is processing.
3. Confirm `queueTime` and `totalTime` appear alongside `elapsedTime`, and that `elapsedTime` is omitted while the replay is still queued.

## Release Notes

`sloctl replay list` now shows `queueTime` and `totalTime` in addition to `elapsedTime`, so users can distinguish queue wait from processing time.
