### PR TITLE
feat: PC-20078 show createdAt in replay list

### DIFF
--- a/internal/replay_list.go
+++ b/internal/replay_list.go
@@ -24,6 +24,7 @@ func (r *ReplayCmd) AddListCommand() *cobra.Command {
 type ReplayListItem struct {
 	Slo            string `json:"slo,omitempty"`
 	Project        string `json:"project"`
+	CreatedAt      string `json:"createdAt,omitempty"`
 	ElapsedTime    string `json:"elapsedTime,omitempty"`
 	RetrievedScope string `json:"retrievedScope,omitempty"`
 	RetrievedFrom  string `json:"retrievedFrom,omitempty"`


### PR DESCRIPTION
## Motivation

`sloctl replay list` drops the `createdAt` field that the replay list endpoint returns for each item, because the response struct has no matching field.

## Summary

Added a `CreatedAt` field to `ReplayListItem` so `createdAt` is decoded from the endpoint response and appears in table, JSON, and YAML output.

## Testing

`sloctl replay list -o json` against a live environment now includes `createdAt` on every row. `elapsedTime` is present for in-progress replays and absent while queued (both unchanged by this PR):

```json
[
  {
    "slo": "payments-latency",
    "project": "reliability-demo",
    "createdAt": "2026-07-24T09:33:01Z",
    "elapsedTime": "1h47m0s",
    "retrievedScope": "34 Day",
    "retrievedFrom": "2026-06-19T23:55:01Z",
    "status": "in progress",
    "cancellation": "possible"
  },
  {
    "slo": "search-latency",
    "project": "reliability-demo",
    "createdAt": "2026-07-24T11:20:09Z",
    "retrievedScope": "34 Day",
    "retrievedFrom": "2026-06-19T23:55:09Z",
    "status": "queued",
    "cancellation": "blocked"
  }
]
```

## Release Notes

`sloctl replay list` now shows `createdAt` for each replay. `elapsedTime` reflects the value returned by the API; with the accompanying server change it measures only the real process time, excluding time spent waiting in the queue, so replay list matches the web UI.

