### PR TITLE
test: use native assert_stderr

### DIFF
--- a/test/docker/Dockerfile.e2e
+++ b/test/docker/Dockerfile.e2e
@@ -1,5 +1,9 @@
 FROM bats/bats:1.14.0
 
+# Pin bats-assert separately because the Bats image lacks assert_stderr.
+ARG BATS_ASSERT_VERSION=2.2.4
+RUN /tmp/docker/install_libs.sh assert "${BATS_ASSERT_VERSION}"
+
 RUN apk --no-cache --update add \
   gettext jq git python3 py3-pip npm
 RUN pip install yq==v3.2.3 --break-system-packages

--- a/test/docker/Dockerfile.unit
+++ b/test/docker/Dockerfile.unit
@@ -1,5 +1,9 @@
 FROM bats/bats:1.14.0
 
+# Pin bats-assert separately because the Bats image lacks assert_stderr.
+ARG BATS_ASSERT_VERSION=2.2.4
+RUN /tmp/docker/install_libs.sh assert "${BATS_ASSERT_VERSION}"
+
 RUN apk --no-cache --update add \
   gettext jq git python3 py3-pip openssl tzdata npm
 RUN pip install yq==v3.2.3 --break-system-packages

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -290,7 +290,7 @@ $stderr" assert_success
 # NOTE: This was copied from bats-assert,
 # once a new version is avilable in the official Docker image, we can abandond this.
 assert_stderr() {
-  output="$stderr"
+  local output="$stderr"
   assert_output "$@"
 }
 

--- a/test/test_helper/load.bash
+++ b/test/test_helper/load.bash
@@ -259,41 +259,6 @@ assert_success_joined_output() {
 $stderr" assert_success
 }
 
-# assert_stderr
-# =============
-#
-# Summary: Fail if `$stderr' does not match the expected stderr.
-#
-# Usage: assert_stderr [-p | -e] [- | [--] <expected>]
-#
-# Options:
-#   -p, --partial  Match if `expected` is a substring of `$stderr`
-#   -e, --regexp   Treat `expected` as an extended regular expression
-#   -, --stdin     Read `expected` value from STDIN
-#   <expected>     The expected value, substring or regular expression
-#
-# IO:
-#   STDIN - [=$1] expected stderr
-#   STDERR - details, on failure
-#            error message, on error
-# Globals:
-#   stderr
-# Returns:
-#   0 - if stderr matches the expected value/partial/regexp
-#   1 - otherwise
-#
-# Similarly to `assert_output`, this function verifies that a command or function produces the expected stderr.
-# (It is the logical complement of `refute_stderr`.)
-# The stderr matching can be literal (the default), partial or by regular expression.
-# The expected stderr can be specified either by positional argument or read from STDIN by passing the `-`/`--stdin` flag.
-#
-# NOTE: This was copied from bats-assert,
-# once a new version is avilable in the official Docker image, we can abandond this.
-assert_stderr() {
-  local output="$stderr"
-  assert_output "$@"
-}
-
 # run_mcp_inspector
 # ==========
 #


### PR DESCRIPTION
## Motivation

The Bats image bundles a `bats-assert` version without `assert_stderr`, so the test suite maintained a copied wrapper. That wrapper replaced captured stdout with stderr and broke tests that checked both streams.

## Summary

Pinned `bats-assert` 2.2.4 in the unit and end-to-end test images and removed the copied wrapper. The native assertion reads stderr without changing the captured stdout.

## Testing

Verified in the rebuilt test image that native `assert_stderr` validates stderr while a following `assert_output` still receives the original stdout.
