### PR TITLE
test: sort project label values

### DIFF
--- a/test/inputs/get/projects.yaml
+++ b/test/inputs/get/projects.yaml
@@ -9,8 +9,8 @@
       - defensive
       - offensive
       team:
-      - vader
       - sidious
+      - vader
   spec:
     description: Dummy Project for 'sloctl get' e2e tests
 - apiVersion: n9/v1alpha


### PR DESCRIPTION
## Motivation

The Nobl9 API now returns label values in deterministic lexical order. The project fixture expected the previous order, so project retrieval assertions no longer matched API responses.

## Summary

Aligned the expected project label values with the API's lexical order.

## Testing

Validated the project fixture YAML and confirmed that its multi-value labels are sorted.
